### PR TITLE
Use static array to confirm vendoredPackage output.

### DIFF
--- a/tests/vendored-package-test.js
+++ b/tests/vendored-package-test.js
@@ -7,7 +7,6 @@ var broccoli = require('broccoli');
 
 var vendoredPackage = require('../lib/vendored-package');
 var testLibPath     = path.join(__dirname, 'fixtures/packages/loader/lib');
-var expectedPath    = path.join(__dirname, 'expected/packages/loader');
 
 /*
   Input:
@@ -39,7 +38,7 @@ describe('vendored-package', function() {
       .then(function(results) {
         var outputPath = results.directory;
 
-        expect(walkSync(outputPath)).to.deep.equal(walkSync(expectedPath));
+        expect(walkSync(outputPath)).to.deep.equal(['loader/', 'loader.js']);
       });
   });
 });


### PR DESCRIPTION
I would definitely prefer to compare output directories, but we can't add empty directories to .git (and adding a `.gitkeep` makes it included in the comparison results).

Once we move to funnel, this won't be an issue (it doesn't make these empty subdirs).
