### PR TITLE
Generate CJS output during development builds.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -208,7 +208,8 @@ EmberBuild.prototype.getDistTrees = function getDistTrees() {
     this._compiledTests,
     this._testingCompiledSource,
     testConfig,
-    bowerFiles
+    bowerFiles,
+    buildCJSTree(this._compiledSource)
   ];
 
   // If you are not running in dev add Production and Minify build to distTrees.
@@ -225,7 +226,6 @@ EmberBuild.prototype.getDistTrees = function getDistTrees() {
     }
 
     distTrees.push(buildRuntimeTree());
-    distTrees.push(buildCJSTree(this._compiledSource));
   }
 
   // merge distTrees and sub out version placeholders for distribution


### PR DESCRIPTION
This is not adding significant time, and it will likely be easier for
the SSR work.
