### PR TITLE
Cache `npm install` in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 
 sudo: false
+
+cache:
+  directories:
+    - node_modules


### PR DESCRIPTION
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

Running CI in docker container should be more performant. This is already
being done in
[ember/ember.js](https://github.com/emberjs/ember.js/blob/dca9c74de7136deff79b9cb2f2de4f6b6b8237c7/.travis.yml#L6-L10)