### PR TITLE
Allow Configuration

### DIFF
--- a/lib/build-cjs-tree.js
+++ b/lib/build-cjs-tree.js
@@ -4,12 +4,15 @@ var concat     = require('broccoli-concat');
 var writeFile  = require('broccoli-file-creator');
 var mergeTrees = require('broccoli-merge-trees');
 
-module.exports = function buildCJSTree(compiledSourceTree) {
-  var exportsTree = writeFile('export-ember', ';module.exports = Ember;\n');
+module.exports = function buildCJSTree(compiledSourceTree, opts) {
+  var options = opts || {};
+  var name = options.name || 'ember';
+  var namespace = options.namespace || 'Ember';
+  var exportsTree = writeFile('export-' + name, ';module.exports = ' + namespace + ';\n');
 
   return concat(mergeTrees([compiledSourceTree, exportsTree]), {
     wrapInEval: false,
-    inputFiles: ['ember.debug.js', 'export-ember'],
-    outputFile: '/ember.debug.cjs.js'
+    inputFiles: [name + '.debug.js', 'export-' + name],
+    outputFile: '/' + name + '.debug.cjs.js'
   });
 };

--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -28,7 +28,11 @@ function EmberBuild(options) {
   this._init();
 
   if (options && options.packages) {
-    this._packages = options.packages;
+    this._packages      = options.packages;
+    this._name          = options.name || 'ember';
+    this._namespace     = options.namespace || 'Ember';
+    this._skipRuntime   = options.skipRuntime;
+    this._skipTemplates = options.skipTemplates;
 
     this._trees.distTrees = [
       this._generateCompiledSourceTree,
@@ -36,8 +40,11 @@ function EmberBuild(options) {
       this._generateTestingCompiledSourceTree,
       this._getTestConfigTree,
       this._getBowerTree,
-      this._buildTemplateCompilerTree
     ];
+
+    if (!this._skipTemplates) {
+      this._trees.distTrees.push(this._buildTemplateCompilerTree);
+    }
 
     this._trees.prodTrees = [
       this._generateDeprecatedDebugFileTree,
@@ -59,7 +66,11 @@ EmberBuild.prototype._concatenateES6Modules = concatenateES6Modules;
 EmberBuild.prototype._buildTemplateCompilerTree = buildTemplateCompilerTree;
 
 EmberBuild.prototype._init = function init() {
-  this._packages = null;
+  this._packages      = null;
+  this._name          = null;
+  this._namespace     = null;
+  this._skipRuntime   = null;
+  this._skipTemplates = null;
 
   this._trees = {
     buildTree:             null,
@@ -83,10 +94,10 @@ EmberBuild.prototype._generateCompiledSourceTree = function generateCompiledSour
   var buildTree = this._enumeratePackages();
 
   return this._trees.compiledSource = this._concatenateES6Modules(buildTree.devSourceTrees, {
-    destFile:        '/ember.debug.js',
+    destFile:        '/' + this._name + '.debug.js',
     vendorTrees:     buildTree.vendorTrees,
     includeLoader:   true,
-    bootstrapModule: 'ember'
+    bootstrapModule: this._name
   });
 };
 
@@ -95,10 +106,10 @@ EmberBuild.prototype._generateProdCompiledSourceTree = function generateProdComp
   var buildTree = this._enumeratePackages();
 
   return this._trees.prodCompiledSource = this._concatenateES6Modules(buildTree.prodSourceTrees, {
-    destFile:        '/ember.prod.js',
+    destFile:        '/' + this._name + '.prod.js',
     vendorTrees:     buildTree.vendorTrees,
     includeLoader:   true,
-    bootstrapModule: 'ember',
+    bootstrapModule: this._name,
     defeatureifyOptions: {
       stripDebug: true,
       environment: 'production'
@@ -108,7 +119,7 @@ EmberBuild.prototype._generateProdCompiledSourceTree = function generateProdComp
 
 EmberBuild.prototype._generateDeprecatedDebugFileTree = function generateDeprecatedDebugFileTree() {
   this._trees.deprecatedDebugFile = replace(this._trees.compiledSource, {
-    files: [ 'ember.debug.js' ],
+    files: [ this._name + '.debug.js' ],
     patterns: [{
       match: /var runningNonEmberDebugJS = false;/,
       replacement: 'var runningNonEmberDebugJS = true;'
@@ -116,8 +127,8 @@ EmberBuild.prototype._generateDeprecatedDebugFileTree = function generateDepreca
   });
 
   return this._trees.deprecatedDebugFile = concat(this._trees.deprecatedDebugFile, {
-    inputFiles: [ 'ember.debug.js' ],
-    outputFile: '/ember.js'
+    inputFiles: [ this._name + '.debug.js' ],
+    outputFile: '/' + this._name + '.js'
   });
 };
 
@@ -126,7 +137,7 @@ EmberBuild.prototype._generateCompiledTestsTree = function generateCompiledTests
   var buildTree = this._enumeratePackages();
 
   return this._trees.compiledTests = this._concatenateES6Modules(buildTree.testTree, {
-    destFile:      '/ember-tests.js',
+    destFile:      '/' + this._name + '-tests.js',
     includeLoader: true
   });
 };
@@ -137,7 +148,7 @@ EmberBuild.prototype._generateProdCompiledTestsTree = function generateProdCompi
   var buildTree = this._enumeratePackages();
 
   return this._trees.prodCompiledTests = this._concatenateES6Modules(buildTree.testTree, {
-    destFile:      '/ember-tests.prod.js',
+    destFile:      '/' + this._name + '-tests.prod.js',
     includeLoader: true,
     defeatureifyOptions: {
       environment: 'production'
@@ -150,17 +161,17 @@ EmberBuild.prototype._generateTestingCompiledSourceTree = function generateTesti
   var buildTree = this._enumeratePackages();
 
   return this._trees.testingCompiledSource = this._concatenateES6Modules(buildTree.testingSourceTrees, {
-    destFile:      '/ember-testing.js',
+    destFile:      '/' + this._name + '-testing.js',
     includeLoader: true,
-    bootstrapModule: 'ember-testing'
+    bootstrapModule: this._name + '-testing'
   });
 };
 
 // Take prod output and minify. This reduces filesize (as you'd expect)
 EmberBuild.prototype._generateMinifiedCompiledSourceTree = function generateMinifiedCompiledSourceTree() {
   return this._trees.minCompiledSource = minifySourceTree(this._trees.prodCompiledSource, {
-    srcFile:  'ember.prod.js',
-    destFile: 'ember.min.js',
+    srcFile:  this._name + '.prod.js',
+    destFile: this._name + '.min.js',
     mangle:   true,
     compress: true
   });
@@ -231,7 +242,10 @@ EmberBuild.prototype.getDistTrees = function getDistTrees() {
     );
   }
 
-  distTrees.push(this._buildCJSTree(this._trees.compiledSource));
+  distTrees.push(this._buildCJSTree(this._trees.compiledSource, {
+    name: this._name,
+    namespace: this._namespace
+  }));
 
   // If you are not running in dev add Production and Minify build to distTrees.
   // This ensures development build speed is not affected by unnecessary
@@ -247,7 +261,9 @@ EmberBuild.prototype.getDistTrees = function getDistTrees() {
       distTrees.push(this._generateMinifiedCompiledSourceTree());
     }
 
-    distTrees.push(this._buildRuntimeTree(this._packages));
+    if (!this._skipRuntime) {
+      distTrees.push(this._buildRuntimeTree(this._packages));
+    }
   }
 
   // merge distTrees and sub out version placeholders for distribution


### PR DESCRIPTION
Changes driven by attempting to integrate with [emberjs/data][1]

* configure an output build name and namespace
* skip building template compiler
* skip building the runtime

[1]: https://github.com/emberjs/data