### PR TITLE
Ensure runtime tree receives the packages.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -247,7 +247,7 @@ EmberBuild.prototype.getDistTrees = function getDistTrees() {
       distTrees.push(this._generateMinifiedCompiledSourceTree());
     }
 
-    distTrees.push(this._buildRuntimeTree());
+    distTrees.push(this._buildRuntimeTree(this._packages));
   }
 
   // merge distTrees and sub out version placeholders for distribution

--- a/lib/get-build-runtime-tree.js
+++ b/lib/get-build-runtime-tree.js
@@ -25,7 +25,7 @@ module.exports = function buildRuntimeTree(packages) {
   var runtimeVendorTrees = packages['ember-runtime'].vendorRequirements.map(function(req){ return vendoredPackages[req];});
 
   packages['ember-runtime'].requirements.forEach(function(req){
-    es6Package(req);
+    es6Package(packages, req);
     runtimeTrees.push(packages[req].trees.lib);
     (packages[req].vendorRequirements || []).forEach(function(vreq) {
       runtimeVendorTrees.push(vendoredPackages[vreq]);


### PR DESCRIPTION
Fixes errors after https://github.com/emberjs/emberjs-build/commit/16f0b20867ff6d010457501f9da37205c4fc92c7.

See https://travis-ci.org/emberjs/ember.js/jobs/46403805 for an example.