### PR TITLE
Allow no files to be matched during concat step.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -106,7 +106,8 @@ module.exports = function concatenateES6Modules(inputTrees, options) {
   var concattedES6 = concat(mergeTrees(concatTrees), {
     wrapInEval: mergedOptions.wrapInEval,
     inputFiles: inputFiles,
-    outputFile: destFile
+    outputFile: destFile,
+    allowNone: true
   });
 
   if (mergedOptions.derequire && !disableDerequire) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "broccoli": "0.12.0",
-    "broccoli-concat": "0.0.6",
+    "broccoli-concat": "0.0.12",
     "broccoli-defeatureify": "~0.3.0",
     "broccoli-derequire": "0.0.1",
     "broccoli-es3-safe-recast": "0.0.8",


### PR DESCRIPTION
The `ember` package has only a single file `lib/main.js` which is moved to `ember.js`, but we are globbing and selecting `ember/**/*.js` which does not match any files (since there are no sub-folders).

This fixes the Ember build, and allows us to update it again.