### PR TITLE
Add easy tree debugging.

### DIFF
--- a/lib/config/build-config.js
+++ b/lib/config/build-config.js
@@ -14,6 +14,8 @@ var disableES3    = !!process.env.DISABLE_ES3 || false;
 var disableMin    = !!process.env.DISABLE_MIN || false;
 var enableDocs    = !!process.env.ENABLE_DOCS || false;
 
+var enableTreeDebugging = !!process.env.ENABLE_TREE_DEBUGGING || false;
+
 var disableDefeatureify;
 
 var disableDerequire = !!process.env.DISABLE_DEREQUIRE || false;
@@ -35,5 +37,6 @@ module.exports = {
   disableMin:          disableMin,
   enableDocs:          enableDocs,
   disableDefeatureify: disableDefeatureify,
-  disableDerequire:    disableDerequire
+  disableDerequire:    disableDerequire,
+  enableTreeDebugging: enableTreeDebugging
 };

--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 // TODO: Move line 4 to line 7 out of here
 var concat       = require('broccoli-concat');
 var replace      = require('broccoli-replace');
@@ -7,6 +8,7 @@ var mergeTrees   = require('broccoli-merge-trees');
 var yuidocPlugin = require('ember-cli-yuidoc');
 var CoreObject   = require('core-object');
 
+var debug                  = require('./utils/debug-tree');
 var es6Package             = require('./get-es6-package');
 var buildConfig            = require('./config/build-config');
 var getBowerTree           = require('./bower-tree');
@@ -90,14 +92,14 @@ var EmberBuild = CoreObject.extend({
   _generateCompiledSourceTree: function generateCompiledSourceTree() {
     var buildTree = this._enumeratePackages();
 
-    var compiledSource = this._concatenateES6Modules(buildTree.devSourceTrees, {
+    var compiledSource = this._concatenateES6Modules(debug(buildTree.devSourceTrees, 'dev-source-trees'), {
       destFile:        '/' + this._name + '.debug.js',
       vendorTrees:     buildTree.vendorTrees,
       includeLoader:   true,
       bootstrapModule: this._name
     });
 
-    return this._trees.compiledSource = this._replaceFeatures(compiledSource, {
+    return this._trees.compiledSource = this._replaceFeatures(debug(compiledSource, 'compiled-source'), {
       files: [ 'ember.debug.js' ]
     });
   },

--- a/lib/utils/debug-tree.js
+++ b/lib/utils/debug-tree.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var _debug = require('broccoli-stew').debug;
+var buildConfig = require('../config/build-config');
+var mergeTrees = require('broccoli-merge-trees');
+
+module.exports = function debugTree(tree, name) {
+  if (!buildConfig.enableTreeDebugging) { return tree; }
+
+  var debugResult = _debug(tree, { name: name });
+
+  return mergeTrees([debugResult, tree], { overwrite: true });
+};

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/emberjs/emberjs-build",
   "devDependencies": {
+    "broccoli-stew": "^0.1.6",
     "chai": "^1.10.0",
     "chai-fs": "^0.1.0",
     "mocha": "^2.0.1",

--- a/tests/config/build-config-test.js
+++ b/tests/config/build-config-test.js
@@ -14,7 +14,8 @@ describe('build config', function() {
       disableMin:          false,
       enableDocs:          false,
       disableDefeatureify: true,
-      disableDerequire:    false
+      disableDerequire:    false,
+      enableTreeDebugging: false
     });
   });
 


### PR DESCRIPTION
Build Ember with `ENABLE_TREE_DEBUGGING=true ember s` will create duplicate copies of these trees for easier step review.