### PR TITLE
Do not compile developmentOnly package vendorRequirements in prod.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -92,9 +92,9 @@ var EmberBuild = CoreObject.extend({
   _generateCompiledSourceTree: function generateCompiledSourceTree() {
     var buildTree = this._enumeratePackages();
 
-    var compiledSource = this._concatenateES6Modules(debug(buildTree.devSourceTrees, 'dev-source-trees'), {
+    var compiledSource = this._concatenateES6Modules(buildTree.devSourceTrees, {
       destFile:        '/' + this._name + '.debug.js',
-      vendorTrees:     buildTree.vendorTrees,
+      vendorTrees:     buildTree.devVendorTrees,
       includeLoader:   true,
       bootstrapModule: this._name
     });
@@ -108,9 +108,9 @@ var EmberBuild = CoreObject.extend({
   _generateProdCompiledSourceTree: function generateProdCompiledSourceTree() {
     var buildTree = this._enumeratePackages();
 
-    var prodTree = this._concatenateES6Modules(debug(buildTree.prodSourceTrees, 'prod-source-trees'), {
+    var prodTree = this._concatenateES6Modules(buildTree.prodSourceTrees, {
       destFile:        '/' + this._name + '.prod.js',
-      vendorTrees:     buildTree.vendorTrees,
+      vendorTrees:     buildTree.prodVendorTrees,
       includeLoader:   true,
       bootstrapModule: this._name,
       defeatureifyOptions: {
@@ -146,6 +146,7 @@ var EmberBuild = CoreObject.extend({
 
     return this._trees.compiledTests = this._concatenateES6Modules(buildTree.testTree, {
       destFile:      '/' + this._name + '-tests.js',
+      vendorTrees:     buildTree.testVendorTrees,
       includeLoader: true
     });
   },
@@ -192,11 +193,12 @@ var EmberBuild = CoreObject.extend({
 
     var packages             = this._packages;
     var testTrees            = [emberDevTestHelpers];
-    var compiledPackageTrees = [];
     var devSourceTrees       = [];
-    var vendorTrees          = [];
     var testingSourceTrees   = [];
     var prodSourceTrees      = [];
+    var prodVendorTrees      = [];
+    var devVendorTrees       = [];
+    var testVendorTrees      = [];
 
     for (var packageName in packages) {
       var currentPackage = packages[packageName];
@@ -206,7 +208,22 @@ var EmberBuild = CoreObject.extend({
       if (currentPackage['vendorRequirements']) {
         /* jshint -W083 */
         currentPackage['vendorRequirements'].forEach(function(dependency) {
-          vendorTrees.push(vendoredPackages[dependency]);
+          devVendorTrees.push(vendoredPackages[dependency]);
+          prodVendorTrees.push(vendoredPackages[dependency]);
+        });
+      }
+
+      if (currentPackage['developmentVendorRequirements']) {
+        /* jshint -W083 */
+        currentPackage['developmentVendorRequirements'].forEach(function(dependency) {
+          devVendorTrees.push(vendoredPackages[dependency]);
+        });
+      }
+
+      if (currentPackage['testingVendorRequirements']) {
+        /* jshint -W083 */
+        currentPackage['testingVendorRequirements'].forEach(function(dependency) {
+          testVendorTrees.push(vendoredPackages[dependency]);
         });
       }
 
@@ -214,14 +231,12 @@ var EmberBuild = CoreObject.extend({
         devSourceTrees.push(currentPackage.trees.lib);
 
         if (currentPackage.developmentOnly) {
+          /* do nothing */
+        } else if (currentPackage.testing) {
           testingSourceTrees.push(currentPackage.trees.lib);
         } else {
           prodSourceTrees.push(currentPackage.trees.lib);
         }
-      }
-
-      if (currentPackage.trees.compiledTree) {
-        compiledPackageTrees.push(currentPackage.trees.compiledTree);
       }
 
       if (currentPackage.trees.tests) {
@@ -231,9 +246,10 @@ var EmberBuild = CoreObject.extend({
 
     this._trees.buildTree = {
       testTree:             mergeTrees(testTrees),
-      vendorTrees:          mergeTrees(vendorTrees, { overwrite: true }),
+      prodVendorTrees:      debug(mergeTrees(prodVendorTrees, { overwrite: true}), 'prod-vendor-trees'),
+      devVendorTrees:       debug(mergeTrees(devVendorTrees, { overwrite: true}), 'dev-vendor-trees'),
+      testVendorTrees:      debug(mergeTrees(testVendorTrees, { overwrite: true}), 'test-vendor-trees'),
       devSourceTrees:       mergeTrees(devSourceTrees),
-      compiledPackageTrees: mergeTrees(compiledPackageTrees),
       testingSourceTrees:   testingSourceTrees,
       prodSourceTrees:      prodSourceTrees
     };

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -17,7 +17,7 @@ var vendoredPackages = getVendoredPackages();
 
   Dependency graph looks like this:
   ```
-    'ember-template-compiler':    {trees: null,  vendorRequirements: ['simple-html-tokenizer', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers']},
+    'ember-template-compiler':    {trees: null,  developmentVendorRequirements: ['simple-html-tokenizer', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers']},
   ```
 */
 module.exports = function buildTemplateCompilerTree(packages) {
@@ -25,8 +25,8 @@ module.exports = function buildTemplateCompilerTree(packages) {
   es6Package(packages, 'ember-template-compiler');
 
   var trees = [packages['ember-template-compiler'].trees.lib];
-  var vendorRequirements = packages['ember-template-compiler'].vendorRequirements || [];
-  var vendorTrees = vendorRequirements.map(function(req){ return vendoredPackages[req];});
+  var developmentVendorRequirements = packages['ember-template-compiler'].developmentVendorRequirements || [];
+  var vendorTrees = developmentVendorRequirements.map(function(req){ return vendoredPackages[req];});
 
   var metalSubset = new Funnel(packages['ember-metal'].trees.lib, {
     files: ['ember-metal/core.js'],

--- a/lib/get-es6-package.js
+++ b/lib/get-es6-package.js
@@ -11,7 +11,6 @@ var jscsTree   = require('./jscs-tree');
 var config                    = require('./config/build-config');
 var packageDependencyTree     = require('./get-package-dependency-tree');
 var inlineTemplatePrecompiler = require('./utils/inline-template-precompiler');
-var concatenateES6Modules     = require('./concatenate-es6-modules');
 
 var disableJSHint = config.disableJSHint;
 var disableJSCS   = config.disableJSCS;
@@ -27,7 +26,7 @@ function getES6Package(packages, packageName, opts) {
   /*
     Prematurely returns if already defined. Trees is (will be) an object that looks like:
     ```
-      {lib: libTree, compiledTree: compiledTrees, vendorTrees: vendorTrees};
+      {lib: libTree, vendorTrees: vendorTrees};
     ```
   */
   if (pkg['trees']) {
@@ -38,7 +37,7 @@ function getES6Package(packages, packageName, opts) {
     Recursively load dependency graph as outlined in `lib/packages.js`
     #TODO: moar detail!!!
   */
-  var dependencyTrees = packageDependencyTree(packages, packageName);
+  packageDependencyTree(packages, packageName);
   var vendorTrees = pkg.vendorTrees;
 
   /*
@@ -133,39 +132,9 @@ function getES6Package(packages, packageName, opts) {
 
   testTrees = testTrees.length > 0 ? mergeTrees(testTrees, { overwrite: true }) : testTree;
 
-  var compiledLib = concatenateES6Modules([dependencyTrees, libTree], {
-    includeLoader: true,
-    vendorTrees: vendorTrees,
-    inputFiles: [
-      packageName + '/**/*.js',
-      packageName + '.js'
-    ],
-    destFile: '/packages/' + packageName + '.js',
-    loader: options.loader,
-    generators: options.generators
-  });
-
-  var compiledTrees = [compiledLib];
-
-  /*
-    Produces tree for packages.  This will eventually be merged into a single
-    file for use in browser tests.
-  */
-  var compiledTest = concatenateES6Modules(testTrees, {
-    includeLoader: false,
-    destFile:      '/packages/' + packageName + '-tests.js',
-    loader:        options.loader,
-    generators:    options.generators
-  });
-
-  if (!pkg.skipTests) { compiledTrees.push(compiledTest); }
-
-  compiledTrees = mergeTrees(compiledTrees);
-
   // Memoizes trees. Guard above ensures that if this is set will automatically return.
   pkg['trees'] = {
     lib:          libTree,
-    compiledTree: compiledTrees,
     vendorTrees:  vendorTrees
   };
 

--- a/lib/htmlbars-package.js
+++ b/lib/htmlbars-package.js
@@ -20,11 +20,11 @@ module.exports = function htmlbarsPackage(packageName, _options) {
   var includes = [];
 
   if (!options.singleFile) {
-    includes.push(/js$/);
+    includes.push(packageName + '/**/*.js');
   }
 
   if (!options.ignoreMain) {
-    includes.push(new RegExp(packageName + '.js'));
+    includes.push(packageName + '.js');
   }
 
   var tree = new Funnel(options.libPath || 'node_modules/htmlbars/dist/es6/', {

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -52,9 +52,7 @@ describe('ember-build', function() {
       var actual = emberBuild._enumeratePackages();
 
       expect(actual.testTree).to.be.ok();
-      expect(actual.vendorTrees).to.be.ok();
       expect(actual.devSourceTrees).to.be.ok();
-      expect(actual.compiledPackageTrees).to.be.ok();
       expect(actual.testingSourceTrees).to.be.ok();
       expect(actual.prodSourceTrees).to.be.ok();
     });

--- a/tests/expected/htmlbars/htmlbars-test-helpers.js
+++ b/tests/expected/htmlbars/htmlbars-test-helpers.js
@@ -1,0 +1,1 @@
+define("htmlbars-test-helpers",  ["exports"],  function(__exports__) {    "use strict";    function foo() {    }    __exports__.foo = foo;function bar() {    }    __exports__.bar = bar;  });

--- a/tests/fixtures/htmlbars/dist/es6/htmlbars-test-helpers.js
+++ b/tests/fixtures/htmlbars/dist/es6/htmlbars-test-helpers.js
@@ -1,0 +1,7 @@
+export function foo() {
+
+}
+
+export function bar() {
+
+}

--- a/tests/get-es6-package-test.js
+++ b/tests/get-es6-package-test.js
@@ -125,40 +125,6 @@ describe('get-es6-package', function() {
       });
   });
 
-  it('correctly creates a compiled tree', function() {
-    var packages = {
-      'ember-metal': { }
-    };
-
-    fixtureLibPath        = path.join(__dirname, 'fixtures/packages/ember-metal/lib');
-    fixtureTestPath       = path.join(__dirname, 'fixtures/packages/ember-metal/tests');
-    fixtureLoaderPath     = path.join(__dirname, 'fixtures/loader');
-    fixtureGeneratorsPath = path.join(__dirname, 'fixtures/generators');
-
-    var loaderTree = new Funnel(fixtureLoaderPath, {
-      files: ['loader.js'],
-      destDir: '/'
-    });
-
-    var fullTree = getES6Package(packages, 'ember-metal', {
-      libPath:    fixtureLibPath,
-      testPath:   fixtureTestPath,
-      loader:     loaderTree,
-      generators: fixtureGeneratorsPath
-    });
-
-    builder = new broccoli.Builder(fullTree.compiledTree);
-
-    expectedPath = path.join(__dirname, 'expected/packages/ember-metal-compiled-tree/');
-
-    return builder.build()
-      .then(function(results) {
-        var outputPath = results.directory;
-
-        expect(walkSync(outputPath)).to.deep.equal(walkSync(expectedPath));
-      });
-  });
-
   it('correctly creates a vendor tree', function() {
     var packages = {
       'ember-template-compiler': {
@@ -201,41 +167,6 @@ describe('get-es6-package', function() {
         var outputPath = results.directory;
 
         expect(walkSync(outputPath)).to.deep.equal([
-          'htmlbars-compiler/',
-          'htmlbars-compiler/compiler.js',
-          'htmlbars-compiler/fragment-javascript-compiler.js',
-          'htmlbars-compiler/fragment-opcode-compiler.js',
-          'htmlbars-compiler/hydration-javascript-compiler.js',
-          'htmlbars-compiler/hydration-opcode-compiler.js',
-          'htmlbars-compiler/template-compiler.js',
-          'htmlbars-compiler/template-visitor.js',
-          'htmlbars-compiler/utils.js',
-          'htmlbars-compiler.js',
-          'htmlbars-runtime/',
-          'htmlbars-runtime/helpers.js',
-          'htmlbars-runtime/hooks.js',
-          'htmlbars-runtime.js',
-          'htmlbars-syntax/',
-          'htmlbars-syntax/builders.js',
-          'htmlbars-syntax/handlebars/',
-          'htmlbars-syntax/handlebars/compiler/',
-          'htmlbars-syntax/handlebars/compiler/ast.js',
-          'htmlbars-syntax/handlebars/compiler/base.js',
-          'htmlbars-syntax/handlebars/compiler/helpers.js',
-          'htmlbars-syntax/handlebars/compiler/parser.js',
-          'htmlbars-syntax/handlebars/compiler/visitor.js',
-          'htmlbars-syntax/handlebars/compiler/whitespace-control.js',
-          'htmlbars-syntax/handlebars/exception.js',
-          'htmlbars-syntax/handlebars/safe-string.js',
-          'htmlbars-syntax/handlebars/utils.js',
-          'htmlbars-syntax/node-handlers.js',
-          'htmlbars-syntax/parser.js',
-          'htmlbars-syntax/token-handlers.js',
-          'htmlbars-syntax/tokenizer.js',
-          'htmlbars-syntax/utils.js',
-          'htmlbars-syntax/walker.js',
-          'htmlbars-syntax.js',
-          'htmlbars-test-helpers.js',
           'htmlbars-util/',
           'htmlbars-util/array-utils.js',
           'htmlbars-util/handlebars/',
@@ -244,32 +175,7 @@ describe('get-es6-package', function() {
           'htmlbars-util/object-utils.js',
           'htmlbars-util/quoting.js',
           'htmlbars-util/safe-string.js',
-          'htmlbars-util.js',
-          'htmlbars.js',
-          'morph/',
-          'morph/attr-morph/',
-          'morph/attr-morph/sanitize-attribute-value.js',
-          'morph/attr-morph.js',
-          'morph/dom-helper/',
-          'morph/dom-helper/build-html-dom.js',
-          'morph/dom-helper/classes.js',
-          'morph/dom-helper/prop.js',
-          'morph/dom-helper.js',
-          'morph/morph.js',
-          'morph.js',
-          'simple-html-tokenizer/',
-          'simple-html-tokenizer/char-refs/',
-          'simple-html-tokenizer/char-refs/full.js',
-          'simple-html-tokenizer/char-refs/min.js',
-          'simple-html-tokenizer/entity-parser.js',
-          'simple-html-tokenizer/generate.js',
-          'simple-html-tokenizer/generator.js',
-          'simple-html-tokenizer/tokenize.js',
-          'simple-html-tokenizer/tokenizer.js',
-          'simple-html-tokenizer/tokens.js',
-          'simple-html-tokenizer/utils.js',
-          'simple-html-tokenizer.js',
-          'simple-html-tokenizer.umd.js'
+          'htmlbars-util.js'
         ]);
       });
   });

--- a/tests/htmlbars-package-test.js
+++ b/tests/htmlbars-package-test.js
@@ -1,9 +1,11 @@
 'use strict';
 
+var path     = require('path');
 var expect   = require('chai').expect;
 var walkSync = require('walk-sync');
 var broccoli = require('broccoli');
 
+var readContent = require('./helpers/file');
 var htmlbarsPackage = require('../lib/htmlbars-package');
 var testLibPath     = 'tests/fixtures/htmlbars/dist/es6/';
 
@@ -32,7 +34,6 @@ describe('htmlbars-package', function() {
   */
   it('correctly creates a htmlbars tree', function() {
     var expected = [
-      'htmlbars-test-helpers.js',
       'htmlbars-util/',
       'htmlbars-util/safe-string.js',
       'htmlbars-util.js'
@@ -72,6 +73,11 @@ describe('htmlbars-package', function() {
         var outputPath = results.directory;
 
         expect(walkSync(outputPath)).to.deep.equal(['htmlbars-test-helpers.js']);
+
+        var actualContents = readContent(path.join(outputPath, 'htmlbars-test-helpers.js'));
+        var expectedContents = readContent('tests/expected/htmlbars/htmlbars-test-helpers.js');
+
+        expect(actualContents).to.be.equal(expectedContents);
       });
   });
 });


### PR DESCRIPTION
* Remove dead code.
* Split dev vendor trees and prod vendor trees.
* Ensure that `htmlbarsPackage` only returns the specific package (not
  all packages).
* Add `test` only vendor components.
* Incorporate `test` only requirements into `this._name + '-tests.js'`
  file.