### PR TITLE
Upgraded git-repo-version to 0.1.0 (Support for tags)

### DIFF
--- a/lib/utils/replace-version.js
+++ b/lib/utils/replace-version.js
@@ -5,12 +5,13 @@ var getVersion = require('git-repo-version');
 
 module.exports = function replaceVersion(trees, options) {
   var opts = options || {};
+  var version = getVersion().replace(/^v/, '');
 
   return replace(trees, {
     files: [ '**/*.js', '**/*.json' ],
     patterns: [{
       match:       opts.placeholder || /VERSION_STRING_PLACEHOLDER/g,
-      replacement: opts.version     || getVersion()
+      replacement: opts.version     || version
     }]
   });
 };

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "core-object": "0.0.4",
     "ember-cli-yuidoc": "0.3.1",
     "es6-module-transpiler": "~0.4.0",
-    "git-repo-version": "0.0.3",
+    "git-repo-version": "0.1.0",
     "htmlbars": "^0.8.0",
     "lodash-node": "^2.4.1"
   }


### PR DESCRIPTION
That module was created to extract the way ember.js and ember-data builds were tagged. That means that it took the version number in the packate.json and added the SHA (8 digits) if the version contained the
`+` sign, like in `1.11.0-beta.1+canary`, turning it into `1.11.0-beta.1+canary.1a2b3d4d`

Git repo version now first of all looks if the current commit is tagged. In that case, it just returns the tag. P.e `v1.10.0-beta.4`.

If the commit is not tagged, it returns the the version in the package.json followed by the SHA, always.

I think this workflow can also work for ember.js and ember-data without any problem, escept that seems that ember.js tags contains a `v` at the beginning, while the version number in package.json doesn't, so it has to be deleted.
