### PR TITLE
Accept Vendor Packages

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -18,7 +18,6 @@ var getVendoredPackages = require('./get-vendored-packages');
 
 var disableES3          = buildConfig.disableES3;
 var disableDerequire    = buildConfig.disableDerequire;
-var vendoredPackages    = getVendoredPackages();
 var disableDefeatureify = buildConfig.disableDefeatureify;
 
 var iifeStart = writeFile('iife-start', '(function() {');
@@ -36,7 +35,8 @@ var defaultOptions = {
   (immediately-invoked function expression)
 */
 module.exports = function concatenateES6Modules(inputTrees, options) {
-  var mergedOptions = merge({}, defaultOptions, options || {});
+  var mergedOptions = merge(defaultOptions, options || {});
+  var vendoredPackages  = mergedOptions.vendoredPackages || getVendoredPackages();
   var loader        = options.loader || vendoredPackages['loader'];
   var inputFiles    = mergedOptions.inputFiles;
   var destFile      = mergedOptions.destFile;

--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -25,7 +25,6 @@ var concatenateES6Modules  = require('./concatenate-es6-modules');
 
 var buildTemplateCompilerTree = require('./get-build-template-compiler-tree');
 
-var vendoredPackages    = getVendoredPackages();
 var emberDevTestHelpers = getEmberDevTestHelpers();
 
 var EmberBuild = CoreObject.extend({
@@ -34,6 +33,7 @@ var EmberBuild = CoreObject.extend({
   _namespace:     null,
   _skipRuntime:   null,
   _skipTemplates: null,
+  _vendoredPackages: null,
 
   _trees:         {
     buildTree:             null,
@@ -55,6 +55,7 @@ var EmberBuild = CoreObject.extend({
       this._namespace     = options.namespace || 'Ember';
       this._skipRuntime   = options.skipRuntime;
       this._skipTemplates = options.skipTemplates;
+      this._vendoredPackages = options.vendoredPackages;
 
       this._trees.distTrees = [
         this._generateCompiledSourceTree,
@@ -199,11 +200,14 @@ var EmberBuild = CoreObject.extend({
     var prodVendorTrees      = [];
     var devVendorTrees       = [];
     var testVendorTrees      = [];
+    var vendoredPackages     = this._vendoredPackages || getVendoredPackages();
 
     for (var packageName in packages) {
       var currentPackage = packages[packageName];
 
-      currentPackage.trees = es6Package(packages, packageName);
+      currentPackage.trees = es6Package(packages, packageName, {
+        vendoredPackages: vendoredPackages
+      });
 
       if (currentPackage['vendorRequirements']) {
         /* jshint -W083 */

--- a/lib/es6-vendored-package.js
+++ b/lib/es6-vendored-package.js
@@ -27,6 +27,13 @@ module.exports = function vendoredES6Package(packageName, opts) {
   var options = opts || {};
 
   var tree = new Funnel(options.libPath || 'bower_components/' + packageName + '/lib', {
+    getDestinationPath: function(relativePath) {
+      if (relativePath === 'main.js') {
+        return packageName + '.js';
+      }
+
+      return relativePath;
+    },
     destDir: '/'
   });
 

--- a/lib/get-build-runtime-tree.js
+++ b/lib/get-build-runtime-tree.js
@@ -8,8 +8,6 @@ var es6Package            = require('./get-es6-package');
 var getVendoredPackages   = require('./get-vendored-packages');
 var concatenateES6Modules = require('./concatenate-es6-modules');
 
-var vendoredPackages = getVendoredPackages();
-
 /*
   Resolves dependencies for ember-runtime and compiles / concats them to /ember-runtime.js
 
@@ -18,7 +16,9 @@ var vendoredPackages = getVendoredPackages();
     'ember-runtime': {vendorRequirements: ['rsvp'], requirements: ['container', 'ember-metal']}
   ```
 */
-module.exports = function buildRuntimeTree(packages) {
+module.exports = function buildRuntimeTree(packages, opts) {
+  var options = opts || {};
+  var vendoredPackages = options.vendoredPackages || getVendoredPackages();
   es6Package(packages, 'ember-runtime');
 
   var runtimeTrees = [packages['ember-runtime'].trees.lib];

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -10,8 +10,6 @@ var replaceFeatures       = require('./replace-features');
 var getVendoredPackages   = require('./get-vendored-packages');
 var concatenateES6Modules = require('./concatenate-es6-modules');
 
-var vendoredPackages = getVendoredPackages();
-
 /*
   Resolves dependencies for ember-template-compiler and compiles / concats them to /ember-template-compiler.js
 
@@ -20,7 +18,10 @@ var vendoredPackages = getVendoredPackages();
     'ember-template-compiler':    {trees: null,  templateCompilerVendor: ['simple-html-tokenizer', 'htmlbars-util', 'htmlbars-compiler', 'htmlbars-syntax', 'htmlbars-test-helpers']},
   ```
 */
-module.exports = function buildTemplateCompilerTree(packages) {
+module.exports = function buildTemplateCompilerTree(packages, opts) {
+  var options = opts || {};
+  var vendoredPackages = options.vendoredPackages || getVendoredPackages();
+
   es6Package(packages, 'ember-metal');
   es6Package(packages, 'ember-template-compiler');
 

--- a/lib/get-es6-package.js
+++ b/lib/get-es6-package.js
@@ -37,7 +37,9 @@ function getES6Package(packages, packageName, opts) {
     Recursively load dependency graph as outlined in `lib/packages.js`
     #TODO: moar detail!!!
   */
-  packageDependencyTree(packages, packageName);
+  packageDependencyTree(packages, packageName, {
+    vendoredPackages: options.vendoredPackages
+  });
   var vendorTrees = pkg.vendorTrees;
 
   /*

--- a/lib/get-package-dependency-tree.js
+++ b/lib/get-package-dependency-tree.js
@@ -8,13 +8,13 @@ var mergeTrees = require('broccoli-merge-trees');
 var es6Package          = require('./get-es6-package');
 var getVendoredPackages = require('./get-vendored-packages');
 
-var vendoredPackages = getVendoredPackages();
-
 /*
   Iterate over dependencyTree as specified within `lib/packages.js`.
   Make sure all dependencies are met for each package.
 */
-function packageDependencyTree(packages, packageName) {
+function packageDependencyTree(packages, packageName, opts) {
+  var options = opts || {};
+  var vendoredPackages = options.vendoredPackages || getVendoredPackages();
   var dependencyTrees = packages[packageName]['dependencyTrees'];
 
   // Return if we've already processed this package


### PR DESCRIPTION
Allow `vendorPackages` as a configuration option. If the argument is
missing, fall back to `getVendoredPackages()`