### PR TITLE
Change to Esperanto for compiling Ember's packages.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -8,7 +8,7 @@ var es3recast        = require('broccoli-es3-safe-recast');
 var derequire        = require('broccoli-derequire');
 var mergeTrees       = require('broccoli-merge-trees');
 var defeatureify     = require('broccoli-defeatureify');
-var transpileES6     = require('broccoli-es6-module-transpiler');
+var transpileES6     = require('./utils/transpile-es6');
 var useStrictRemover = require('broccoli-use-strict-remover');
 
 var debug               = require('./utils/debug-tree');
@@ -50,9 +50,7 @@ module.exports = function concatenateES6Modules(inputTrees, options) {
     sourceTrees = inputTrees;
   }
 
-  sourceTrees = transpileES6(sourceTrees, {
-    moduleName: true
-  });
+  sourceTrees = transpileES6(sourceTrees);
 
   sourceTrees = useStrictRemover(sourceTrees);
 

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var esperanto = require('esperanto');
+var map = require('broccoli-stew').map;
+
+module.exports = function(tree, description) {
+  var moduleNames = {};
+
+  var outputTree = map(tree, '**/*.js', function(content, relativePath) {
+    var moduleName = moduleNames[relativePath];
+
+    if (!moduleName) {
+      moduleName = moduleNames[relativePath] = relativePath.slice(0, -3);
+    }
+
+    return esperanto.toAmd(content, {
+      amdName: moduleName,
+      strict: true,
+      _evilES3SafeReExports: true
+      //sourceMap: 'inline',
+      //sourceMapSource: relativePath,
+      //sourceMapFile: moduleName + '.map'
+    }).code;
+  });
+
+  outputTree.description = 'ES6 Modules' + (description ? ': ' + description : '');
+
+  return outputTree;
+};

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "core-object": "0.0.4",
     "ember-cli-yuidoc": "0.3.1",
     "es6-module-transpiler": "~0.4.0",
+    "esperanto": "^0.6.7",
     "git-repo-version": "0.1.0",
     "htmlbars": "^0.8.0",
     "lodash-node": "^2.4.1"

--- a/tests/expected/packages/ember-tests.js
+++ b/tests/expected/packages/ember-tests.js
@@ -1,187 +1,159 @@
 
 (function() {
 
-define("ember-metal",
-  [],
-  function() {
-    "use strict";
+define('ember-metal', function () {
 
-  });
-define("ember-metal.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - .');
-    test('ember-metal.js should pass jshint', function() { 
-      ok(true, 'ember-metal.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/alias",
-  [],
-  function() {
-    "use strict";
+	'use strict';
 
-  });
-define("ember-metal/alias.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal');
-    test('ember-metal/alias.js should pass jshint', function() { 
-      ok(true, 'ember-metal/alias.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/array",
-  [],
-  function() {
-    "use strict";
+});
+define('ember-metal.jshint', function () {
 
-  });
-define("ember-metal/array.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal');
-    test('ember-metal/array.js should pass jshint', function() { 
-      ok(true, 'ember-metal/array.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/binding",
-  [],
-  function() {
-    "use strict";
+  'use strict';
 
+  module('JSHint - .');
+  test('ember-metal.js should pass jshint', function() { 
+    ok(true, 'ember-metal.js should pass jshint.'); 
   });
-define("ember-metal/binding.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal');
-    test('ember-metal/binding.js should pass jshint', function() { 
-      ok(true, 'ember-metal/binding.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/streams/simple",
-  [],
-  function() {
-    "use strict";
 
-  });
-define("ember-metal/streams/simple.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal/streams');
-    test('ember-metal/streams/simple.js should pass jshint', function() { 
-      ok(true, 'ember-metal/streams/simple.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/tests/alias_test",
-  ["ember-metal/alias","ember-metal/properties","ember-metal/property_get","ember-metal/property_set","ember-metal/utils","ember-metal/watching","ember-metal/observer"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__) {
-    "use strict";
-    // jshint ignore: start
-    var alias = __dependency1__["default"];
-    var defineProperty = __dependency2__.defineProperty;
-    var get = __dependency3__.get;
-    var set = __dependency4__.set;
-    var meta = __dependency5__.meta;
-    var isWatching = __dependency6__.isWatching;
-    var addObserver = __dependency7__.addObserver;
-    var removeObserver = __dependency7__.removeObserver;
+});
+define('ember-metal/alias', function () {
 
-    QUnit.module('ember-metal/alias');
+	'use strict';
 
-    test('should proxy get to alt key');
-  });
-define("ember-metal/tests/alias_test.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal/tests');
-    test('ember-metal/tests/alias_test.js should pass jshint', function() { 
-      ok(true, 'ember-metal/tests/alias_test.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/tests/array_test",
-  ["ember-metal/alias","ember-metal/properties","ember-metal/property_get","ember-metal/property_set","ember-metal/utils","ember-metal/watching","ember-metal/observer"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__) {
-    "use strict";
-    // jshint ignore: start
-    var alias = __dependency1__["default"];
-    var defineProperty = __dependency2__.defineProperty;
-    var get = __dependency3__.get;
-    var set = __dependency4__.set;
-    var meta = __dependency5__.meta;
-    var isWatching = __dependency6__.isWatching;
-    var addObserver = __dependency7__.addObserver;
-    var removeObserver = __dependency7__.removeObserver;
+});
+define('ember-metal/alias.jshint', function () {
 
-    QUnit.module('ember-metal/array');
+  'use strict';
 
-    test('should proxy get to alt key');
+  module('JSHint - ember-metal');
+  test('ember-metal/alias.js should pass jshint', function() { 
+    ok(true, 'ember-metal/alias.js should pass jshint.'); 
   });
-define("ember-metal/tests/array_test.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal/tests');
-    test('ember-metal/tests/array_test.js should pass jshint', function() { 
-      ok(true, 'ember-metal/tests/array_test.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/tests/binding_test",
-  ["ember-metal/alias","ember-metal/properties","ember-metal/property_get","ember-metal/property_set","ember-metal/utils","ember-metal/watching","ember-metal/observer"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__) {
-    "use strict";
-    // jshint ignore: start
-    var alias = __dependency1__["default"];
-    var defineProperty = __dependency2__.defineProperty;
-    var get = __dependency3__.get;
-    var set = __dependency4__.set;
-    var meta = __dependency5__.meta;
-    var isWatching = __dependency6__.isWatching;
-    var addObserver = __dependency7__.addObserver;
-    var removeObserver = __dependency7__.removeObserver;
 
-    QUnit.module('ember-metal/binding');
+});
+define('ember-metal/array', function () {
 
-    test('should proxy get to alt key', function() { });
-  });
-define("ember-metal/tests/binding_test.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal/tests');
-    test('ember-metal/tests/binding_test.js should pass jshint', function() { 
-      ok(true, 'ember-metal/tests/binding_test.js should pass jshint.'); 
-    });
-  });
-define("ember-metal/tests/streams/simple_test",
-  ["ember-metal/alias","ember-metal/properties","ember-metal/property_get","ember-metal/property_set","ember-metal/utils","ember-metal/watching","ember-metal/observer"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, __dependency7__) {
-    "use strict";
-    // jshint ignore: start
-    var alias = __dependency1__["default"];
-    var defineProperty = __dependency2__.defineProperty;
-    var get = __dependency3__.get;
-    var set = __dependency4__.set;
-    var meta = __dependency5__.meta;
-    var isWatching = __dependency6__.isWatching;
-    var addObserver = __dependency7__.addObserver;
-    var removeObserver = __dependency7__.removeObserver;
+	'use strict';
 
-    QUnit.module('ember-metal/streams/simple');
+});
+define('ember-metal/array.jshint', function () {
 
-    test('should proxy get to alt key');
+  'use strict';
+
+  module('JSHint - ember-metal');
+  test('ember-metal/array.js should pass jshint', function() { 
+    ok(true, 'ember-metal/array.js should pass jshint.'); 
   });
-define("ember-metal/tests/streams/simple_test.jshint",
-  [],
-  function() {
-    "use strict";
-    module('JSHint - ember-metal/tests/streams');
-    test('ember-metal/tests/streams/simple_test.js should pass jshint', function() { 
-      ok(true, 'ember-metal/tests/streams/simple_test.js should pass jshint.'); 
-    });
+
+});
+define('ember-metal/binding', function () {
+
+	'use strict';
+
+});
+define('ember-metal/binding.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal');
+  test('ember-metal/binding.js should pass jshint', function() { 
+    ok(true, 'ember-metal/binding.js should pass jshint.'); 
   });
+
+});
+define('ember-metal/streams/simple', function () {
+
+	'use strict';
+
+});
+define('ember-metal/streams/simple.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal/streams');
+  test('ember-metal/streams/simple.js should pass jshint', function() { 
+    ok(true, 'ember-metal/streams/simple.js should pass jshint.'); 
+  });
+
+});
+define('ember-metal/tests/alias_test', ['ember-metal/alias', 'ember-metal/properties', 'ember-metal/property_get', 'ember-metal/property_set', 'ember-metal/utils', 'ember-metal/watching', 'ember-metal/observer'], function (alias, properties, property_get, property_set, utils, watching, observer) {
+
+	'use strict';
+
+	// jshint ignore: start
+	QUnit.module('ember-metal/alias');
+
+	test('should proxy get to alt key');
+
+});
+define('ember-metal/tests/alias_test.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal/tests');
+  test('ember-metal/tests/alias_test.js should pass jshint', function() { 
+    ok(true, 'ember-metal/tests/alias_test.js should pass jshint.'); 
+  });
+
+});
+define('ember-metal/tests/array_test', ['ember-metal/alias', 'ember-metal/properties', 'ember-metal/property_get', 'ember-metal/property_set', 'ember-metal/utils', 'ember-metal/watching', 'ember-metal/observer'], function (alias, properties, property_get, property_set, utils, watching, observer) {
+
+	'use strict';
+
+	// jshint ignore: start
+	QUnit.module('ember-metal/array');
+
+	test('should proxy get to alt key');
+
+});
+define('ember-metal/tests/array_test.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal/tests');
+  test('ember-metal/tests/array_test.js should pass jshint', function() { 
+    ok(true, 'ember-metal/tests/array_test.js should pass jshint.'); 
+  });
+
+});
+define('ember-metal/tests/binding_test', ['ember-metal/alias', 'ember-metal/properties', 'ember-metal/property_get', 'ember-metal/property_set', 'ember-metal/utils', 'ember-metal/watching', 'ember-metal/observer'], function (alias, properties, property_get, property_set, utils, watching, observer) {
+
+	'use strict';
+
+	// jshint ignore: start
+	QUnit.module('ember-metal/binding');
+
+	test('should proxy get to alt key', function() { });
+
+});
+define('ember-metal/tests/binding_test.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal/tests');
+  test('ember-metal/tests/binding_test.js should pass jshint', function() { 
+    ok(true, 'ember-metal/tests/binding_test.js should pass jshint.'); 
+  });
+
+});
+define('ember-metal/tests/streams/simple_test', ['ember-metal/alias', 'ember-metal/properties', 'ember-metal/property_get', 'ember-metal/property_set', 'ember-metal/utils', 'ember-metal/watching', 'ember-metal/observer'], function (alias, properties, property_get, property_set, utils, watching, observer) {
+
+	'use strict';
+
+	// jshint ignore: start
+	QUnit.module('ember-metal/streams/simple');
+
+	test('should proxy get to alt key');
+
+});
+define('ember-metal/tests/streams/simple_test.jshint', function () {
+
+  'use strict';
+
+  module('JSHint - ember-metal/tests/streams');
+  test('ember-metal/tests/streams/simple_test.js should pass jshint', function() { 
+    ok(true, 'ember-metal/tests/streams/simple_test.js should pass jshint.'); 
+  });
+
+});
 })();


### PR DESCRIPTION
There are still a number of issues with vendor packages, which is why they are not updated already.

Vendor package issue: using `strict` mode with Esperanto causes `this` in the root of a module to be rewritten to `undefined`. This causes things like backburner to break.  I still need to figure out exactly how to work around that...