### PR TITLE
Ensure JSCS output is escaped properly.

### DIFF
--- a/lib/jscs-tree.js
+++ b/lib/jscs-tree.js
@@ -1,21 +1,14 @@
 'use strict';
 
-var fs = require('fs');
-var jscsTree   = require('broccoli-jscs');
+var JSCS = require('broccoli-jscs');
+var debug = require('./utils/debug-tree');
+var jsStringEscape = require('js-string-escape');
 
-var originalProcessString = jscsTree.prototype.processString;
+// required until https://github.com/kellyselden/broccoli-jscs/pull/16 lands
+JSCS.prototype.escapeErrorString = jsStringEscape;
 
-var jscsConfig = {};
-if (fs.existsSync('.jscsrc')) {
-  jscsConfig = JSON.parse(fs.readFileSync('.jscsrc', { encoding: 'utf8' }));
-}
+module.exports = function(tree, options) {
+  var jscsTree = new JSCS(tree, options);
 
-jscsTree.prototype.processString = function(content, relativePath) {
-  if (jscsConfig.excludeFiles && jscsConfig.excludeFiles.indexOf(relativePath) > -1) {
-    return '';
-  }
-
-  return originalProcessString.call(this, content, relativePath);
+  return debug(jscsTree, 'jscs');
 };
-
-module.exports = jscsTree;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "esperanto": "^0.6.7",
     "git-repo-version": "0.1.0",
     "htmlbars": "^0.10.0",
+    "js-string-escape": "^1.0.0",
     "lodash-node": "^2.4.1"
   }
 }


### PR DESCRIPTION
Fix upstream: https://github.com/kellyselden/broccoli-jscs/pull/16

This is mostly a short-term work around.