### PR TITLE
Do not require HTMLBars from emberjs-build.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -206,6 +206,7 @@ var EmberBuild = CoreObject.extend({
       var currentPackage = packages[packageName];
 
       currentPackage.trees = es6Package(packages, packageName, {
+        htmlbars: this.htmlbars,
         vendoredPackages: vendoredPackages
       });
 

--- a/lib/get-es6-package.js
+++ b/lib/get-es6-package.js
@@ -103,7 +103,9 @@ function getES6Package(packages, packageName, opts) {
       template functions.  This is done so that HTMLBars compiler is
       not required for running Ember.
     */
-    libTree = inlineTemplatePrecompiler(libTree);
+    libTree = inlineTemplatePrecompiler(libTree, {
+      htmlbars: options.htmlbars
+    });
   }
 
   var testTree = new Funnel(options.testPath || 'packages/' + packageName + '/tests', {

--- a/lib/utils/inline-template-precompiler.js
+++ b/lib/utils/inline-template-precompiler.js
@@ -16,7 +16,7 @@ function EmberTemplatePrecompiler (inputTree, options) {
   options = options || {};
   this.inputTree = inputTree;
   this.handlebarsCompilerPath = options.compilerPath || 'ember-template-compiler.js';
-  this.htmlbarsCompiler = require('htmlbars').compileSpec;
+  this.htmlbarsCompiler = options.htmlbars.compileSpec;
 }
 
 EmberTemplatePrecompiler.prototype.extensions = ['hbs'];

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "es6-module-transpiler": "~0.4.0",
     "esperanto": "^0.6.7",
     "git-repo-version": "0.1.2",
-    "htmlbars": "^0.10.0",
     "js-string-escape": "^1.0.0",
     "lodash-node": "^2.4.1"
   }

--- a/tests/get-es6-package-test.js
+++ b/tests/get-es6-package-test.js
@@ -154,6 +154,7 @@ describe('get-es6-package', function() {
     });
 
     var fullTree = getES6Package(packages, 'ember-htmlbars', {
+      htmlbars: { compileSpec: function() { } },
       libPath:    fixtureLibPath,
       testPath:   fixtureTestPath,
       loader:     loaderTree,


### PR DESCRIPTION
It should be supplied from the consuming project (makes tracking the
deps much easier).