### PR TITLE
Allow the use of ES2015 features in Ember build.

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -2,7 +2,7 @@
 
 var esperanto = require('esperanto');
 var map = require('broccoli-stew').map;
-var transpile6to5 = require('6to5-core');
+var babel = require('babel-core');
 
 module.exports = function(tree, description) {
   var moduleNames = {};
@@ -14,7 +14,7 @@ module.exports = function(tree, description) {
       moduleName = moduleNames[relativePath] = relativePath.slice(0, -3);
     }
 
-    content = transpile6to5.transform(content, {
+    content = babel.transform(content, {
       whitelist: ['es6.templateLiterals', 'es6.parameters.rest', 'es6.arrowFunctions']
     }).code;
 

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -2,6 +2,7 @@
 
 var esperanto = require('esperanto');
 var map = require('broccoli-stew').map;
+var transpile6to5 = require('6to5-core');
 
 module.exports = function(tree, description) {
   var moduleNames = {};
@@ -13,6 +14,10 @@ module.exports = function(tree, description) {
       moduleName = moduleNames[relativePath] = relativePath.slice(0, -3);
     }
 
+    content = transpile6to5.transform(content, {
+      blacklist: ['useStrict', 'es6.modules']
+    }).code;
+
     return esperanto.toAmd(content, {
       amdName: moduleName,
       strict: true,
@@ -21,6 +26,7 @@ module.exports = function(tree, description) {
       //sourceMapSource: relativePath,
       //sourceMapFile: moduleName + '.map'
     }).code;
+
   });
 
   outputTree.description = 'ES6 Modules' + (description ? ': ' + description : '');

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -15,7 +15,7 @@ module.exports = function(tree, description) {
     }
 
     content = transpile6to5.transform(content, {
-      blacklist: ['useStrict', 'es6.modules']
+      whitelist: ['es6.templateLiterals', 'es6.parameters.rest', 'es6.arrowFunctions']
     }).code;
 
     return esperanto.toAmd(content, {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "walk-sync": "^0.1.3"
   },
   "dependencies": {
+    "6to5-core": "^3.3.2",
     "broccoli": "0.13.3",
     "broccoli-concat": "0.0.12",
     "broccoli-defeatureify": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "walk-sync": "^0.1.3"
   },
   "dependencies": {
-    "6to5-core": "^3.3.2",
+    "babel-core": "^4.0.0",
     "broccoli": "0.13.3",
     "broccoli-concat": "0.0.12",
     "broccoli-defeatureify": "~1.0.0",

--- a/tests/concatatinate-es6-modules-test.js
+++ b/tests/concatatinate-es6-modules-test.js
@@ -55,7 +55,7 @@ describe('concatenate-es6-modules', function() {
         var fileContent = readContent(filePath);
 
         expect(filePath).to.be.a.path('file exists');
-        expect(fileContent).to.equal(expectedContent);
+        expect(fileContent.replace(/\s+/g, ' ')).to.equal(expectedContent.replace(/\s+/g, ' '));
       });
   });
 });

--- a/tests/expected/packages/ember-tests.js
+++ b/tests/expected/packages/ember-tests.js
@@ -10,9 +10,9 @@ define('ember-metal.jshint', function () {
 
   'use strict';
 
-  module('JSHint - .');
-  test('ember-metal.js should pass jshint', function() { 
-    ok(true, 'ember-metal.js should pass jshint.'); 
+  module("JSHint - .");
+  test("ember-metal.js should pass jshint", function () { 
+    ok(true, "ember-metal.js should pass jshint."); 
   });
 
 });
@@ -25,9 +25,9 @@ define('ember-metal/alias.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal');
-  test('ember-metal/alias.js should pass jshint', function() { 
-    ok(true, 'ember-metal/alias.js should pass jshint.'); 
+  module("JSHint - ember-metal");
+  test("ember-metal/alias.js should pass jshint", function () { 
+    ok(true, "ember-metal/alias.js should pass jshint."); 
   });
 
 });
@@ -40,9 +40,9 @@ define('ember-metal/array.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal');
-  test('ember-metal/array.js should pass jshint', function() { 
-    ok(true, 'ember-metal/array.js should pass jshint.'); 
+  module("JSHint - ember-metal");
+  test("ember-metal/array.js should pass jshint", function () { 
+    ok(true, "ember-metal/array.js should pass jshint."); 
   });
 
 });
@@ -55,9 +55,9 @@ define('ember-metal/binding.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal');
-  test('ember-metal/binding.js should pass jshint', function() { 
-    ok(true, 'ember-metal/binding.js should pass jshint.'); 
+  module("JSHint - ember-metal");
+  test("ember-metal/binding.js should pass jshint", function () { 
+    ok(true, "ember-metal/binding.js should pass jshint."); 
   });
 
 });
@@ -70,9 +70,9 @@ define('ember-metal/streams/simple.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal/streams');
-  test('ember-metal/streams/simple.js should pass jshint', function() { 
-    ok(true, 'ember-metal/streams/simple.js should pass jshint.'); 
+  module("JSHint - ember-metal/streams");
+  test("ember-metal/streams/simple.js should pass jshint", function () { 
+    ok(true, "ember-metal/streams/simple.js should pass jshint."); 
   });
 
 });
@@ -81,18 +81,18 @@ define('ember-metal/tests/alias_test', ['ember-metal/alias', 'ember-metal/proper
 	'use strict';
 
 	// jshint ignore: start
-	QUnit.module('ember-metal/alias');
+	QUnit.module("ember-metal/alias");
 
-	test('should proxy get to alt key');
+	test("should proxy get to alt key");
 
 });
 define('ember-metal/tests/alias_test.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal/tests');
-  test('ember-metal/tests/alias_test.js should pass jshint', function() { 
-    ok(true, 'ember-metal/tests/alias_test.js should pass jshint.'); 
+  module("JSHint - ember-metal/tests");
+  test("ember-metal/tests/alias_test.js should pass jshint", function () { 
+    ok(true, "ember-metal/tests/alias_test.js should pass jshint."); 
   });
 
 });
@@ -101,18 +101,18 @@ define('ember-metal/tests/array_test', ['ember-metal/alias', 'ember-metal/proper
 	'use strict';
 
 	// jshint ignore: start
-	QUnit.module('ember-metal/array');
+	QUnit.module("ember-metal/array");
 
-	test('should proxy get to alt key');
+	test("should proxy get to alt key");
 
 });
 define('ember-metal/tests/array_test.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal/tests');
-  test('ember-metal/tests/array_test.js should pass jshint', function() { 
-    ok(true, 'ember-metal/tests/array_test.js should pass jshint.'); 
+  module("JSHint - ember-metal/tests");
+  test("ember-metal/tests/array_test.js should pass jshint", function () { 
+    ok(true, "ember-metal/tests/array_test.js should pass jshint."); 
   });
 
 });
@@ -121,18 +121,18 @@ define('ember-metal/tests/binding_test', ['ember-metal/alias', 'ember-metal/prop
 	'use strict';
 
 	// jshint ignore: start
-	QUnit.module('ember-metal/binding');
+	QUnit.module("ember-metal/binding");
 
-	test('should proxy get to alt key', function() { });
+	test("should proxy get to alt key", function () {});
 
 });
 define('ember-metal/tests/binding_test.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal/tests');
-  test('ember-metal/tests/binding_test.js should pass jshint', function() { 
-    ok(true, 'ember-metal/tests/binding_test.js should pass jshint.'); 
+  module("JSHint - ember-metal/tests");
+  test("ember-metal/tests/binding_test.js should pass jshint", function () { 
+    ok(true, "ember-metal/tests/binding_test.js should pass jshint."); 
   });
 
 });
@@ -141,18 +141,18 @@ define('ember-metal/tests/streams/simple_test', ['ember-metal/alias', 'ember-met
 	'use strict';
 
 	// jshint ignore: start
-	QUnit.module('ember-metal/streams/simple');
+	QUnit.module("ember-metal/streams/simple");
 
-	test('should proxy get to alt key');
+	test("should proxy get to alt key");
 
 });
 define('ember-metal/tests/streams/simple_test.jshint', function () {
 
   'use strict';
 
-  module('JSHint - ember-metal/tests/streams');
-  test('ember-metal/tests/streams/simple_test.js should pass jshint', function() { 
-    ok(true, 'ember-metal/tests/streams/simple_test.js should pass jshint.'); 
+  module("JSHint - ember-metal/tests/streams");
+  test("ember-metal/tests/streams/simple_test.js should pass jshint", function () { 
+    ok(true, "ember-metal/tests/streams/simple_test.js should pass jshint."); 
   });
 
 });

--- a/tests/fixtures/transpile-es6/arrow-functions/some-file.js
+++ b/tests/fixtures/transpile-es6/arrow-functions/some-file.js
@@ -1,0 +1,19 @@
+// Expression bodies
+var odds = evens.map(v => v + 1);
+var nums = evens.map((v, i) => v + i);
+
+// Statement bodies
+nums.forEach(v => {
+  if (v % 5 === 0)
+    fives.push(v);
+});
+
+// Lexical this
+var bob = {
+  _name: "Bob",
+  _friends: [],
+  printFriends() {
+    this._friends.forEach(f =>
+      console.log(this._name + " knows " + f));
+  }
+}

--- a/tests/utils/transpile-es6-test.js
+++ b/tests/utils/transpile-es6-test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var chai = require('chai');
+var path = require('path');
+var expect = chai.expect;
+var broccoli = require('broccoli');
+
+chai.use(require('chai-fs'));
+
+var readContent = require('../helpers/file');
+var transpileES6 = require('../../lib/utils/transpile-es6');
+var transpileFixtures = path.join(__dirname, '..', 'fixtures', 'transpile-es6');
+
+describe('transpileES6', function() {
+  var builder;
+
+  afterEach(function() {
+    if (builder) {
+      return builder.cleanup();
+    }
+  });
+
+  it('correctly replaces arrowFunctions', function() {
+    var arrowFunctionFixture = path.join(transpileFixtures, 'arrow-functions');
+
+    var tree = transpileES6(arrowFunctionFixture);
+
+    builder = new broccoli.Builder(tree);
+
+    return builder.build()
+      .then(function(results) {
+        var filePath = results.directory + '/some-file.js';
+        var fileContent = readContent(filePath);
+
+        expect(fileContent).not.to.contain('=>');
+      });
+  });
+});


### PR DESCRIPTION
Replaces #68.

This does increase initial boot time (almost double), but does not seem to impact rebuild times.