### PR TITLE
Ember Data uses js files in its tests dir

### DIFF
--- a/lib/config/test-config-tree.js
+++ b/lib/config/test-config-tree.js
@@ -8,7 +8,7 @@ module.exports = function getTestConfigTree(opts) {
   var options = opts || {};
 
   var testConfig = new Funnel(options.libPath || 'tests', {
-    include: [ /html$/ ],
+    include: [ /html$/, /js$/ ],
     destDir: '/tests'
   });
 


### PR DESCRIPTION
Without this change the js files in this directory do not get served by the `ember serve` command https://github.com/emberjs/data/tree/master/tests. Let me know if there is a better place for Ember Data to keep these files.