### PR TITLE
Bumping broccoli-jscs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-file-creator": "~0.1.0",
     "broccoli-filter": "~0.1.10",
     "broccoli-funnel": "^0.1.7",
-    "broccoli-jscs": "0.0.14",
+    "broccoli-jscs": "0.0.19",
     "broccoli-jshint": "^0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.6",
     "broccoli-merge-trees": "0.2.1",


### PR DESCRIPTION
I believe this version includes the fix to unblock https://github.com/emberjs/ember.js/pull/10637 per the discussion at https://github.com/jscs-dev/node-jscs/issues/1171.