### PR TITLE
Add ember-debug to ember-template-compiler.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -35,7 +35,7 @@ var defaultOptions = {
   (immediately-invoked function expression)
 */
 module.exports = function concatenateES6Modules(inputTrees, options) {
-  var mergedOptions = merge(defaultOptions, options || {});
+  var mergedOptions = merge({}, defaultOptions, options || {});
   var vendoredPackages  = mergedOptions.vendoredPackages || getVendoredPackages();
   var loader        = options.loader || vendoredPackages['loader'];
   var inputFiles    = mergedOptions.inputFiles;
@@ -81,7 +81,16 @@ module.exports = function concatenateES6Modules(inputTrees, options) {
   }
 
   if (mergedOptions.bootstrapModule) {
-    var bootstrapTree = writeFile('bootstrap', 'requireModule("' + mergedOptions.bootstrapModule + '");\n');
+    mergedOptions.bootstrapModules = [mergedOptions.bootstrapModule];
+  }
+
+  if (mergedOptions.bootstrapModules) {
+    var contents = mergedOptions.bootstrapModules.map(function(module) {
+      return 'requireModule("' + module + '");';
+    })
+    .join('\n');
+
+    var bootstrapTree = writeFile('bootstrap', contents + '\n');
     concatTrees.push(bootstrapTree);
     inputFiles.push('bootstrap');
   }

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -22,14 +22,20 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
   var vendoredPackages = _vendoredPackages || getVendoredPackages();
 
   es6Package(packages, 'ember-metal');
+  es6Package(packages, 'ember-debug');
   es6Package(packages, 'ember-template-compiler');
 
-  var trees = [packages['ember-template-compiler'].trees.lib];
+  var trees = [packages['ember-template-compiler'].trees.lib, packages['ember-debug'].trees.lib];
   var templateCompilerVendor = packages['ember-template-compiler'].templateCompilerVendor || [];
   var vendorTrees = templateCompilerVendor.map(function(req){ return vendoredPackages[req];});
 
   var metalSubset = new Funnel(packages['ember-metal'].trees.lib, {
-    files: ['ember-metal/core.js'],
+    files: [
+      'ember-metal/core.js',
+      'ember-metal/error.js',
+      'ember-metal/logger.js',
+      'ember-metal/environment.js'
+    ],
     destDir: '/'
   });
 
@@ -41,7 +47,7 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
 
   var compiled = concatenateES6Modules(trees, {
     includeLoader: true,
-    bootstrapModule: 'ember-template-compiler',
+    bootstrapModules: ['ember-debug', 'ember-template-compiler'],
     vendorTrees: mergeTrees(vendorTrees, {overwrite: true}),
     destFile: '/ember-template-compiler.js'
   });

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -79,6 +79,7 @@ describe('ember-build', function() {
         packages: {
           'container': {},
           'ember-metal': {},
+          'ember-debug': {},
           'ember-template-compiler': {}
         }
       });


### PR DESCRIPTION
This is to allow future deprecations to work from within the AST plugins.