### PR TITLE
Bumping JSCS to 0.0.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-file-creator": "~0.1.0",
     "broccoli-filter": "~0.1.10",
     "broccoli-funnel": "^0.1.7",
-    "broccoli-jscs": "0.0.19",
+    "broccoli-jscs": "0.0.20",
     "broccoli-jshint": "^0.5.3",
     "broccoli-kitchen-sink-helpers": "^0.2.6",
     "broccoli-merge-trees": "0.2.1",


### PR DESCRIPTION
Misread what version JSCS only looked at ObjectExpressions for whitespace checking. This included JSCS 0.11.0.