### PR TITLE
Do not limit ember-metal modules for template-compiler.

### DIFF
--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -29,21 +29,11 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
   var templateCompilerVendor = packages['ember-template-compiler'].templateCompilerVendor || [];
   var vendorTrees = templateCompilerVendor.map(function(req){ return vendoredPackages[req];});
 
-  var metalSubset = new Funnel(packages['ember-metal'].trees.lib, {
-    files: [
-      'ember-metal/core.js',
-      'ember-metal/error.js',
-      'ember-metal/logger.js',
-      'ember-metal/environment.js'
-    ],
-    destDir: '/'
-  });
-
-  metalSubset = replaceFeatures(metalSubset, {
+  var metal = replaceFeatures(packages['ember-metal'].trees.lib, {
     files: [ 'ember-metal/core.js' ]
   });
 
-  trees.push(metalSubset);
+  trees.push(metal);
 
   var compiled = concatenateES6Modules(trees, {
     includeLoader: true,

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -3,7 +3,6 @@
 var concat     = require('broccoli-sourcemap-concat');
 var writeFile  = require('broccoli-file-creator');
 var mergeTrees = require('broccoli-merge-trees');
-var Funnel     = require('broccoli-funnel');
 
 var es6Package            = require('./get-es6-package');
 var replaceFeatures       = require('./replace-features');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "chai": "^1.10.0",
     "chai-fs": "^0.1.0",
+    "htmlbars": "^0.11.1",
     "mocha": "^2.0.1",
     "mocha-jshint": "0.0.9",
     "walk-sync": "^0.1.3"


### PR DESCRIPTION
Limiting the packages is a major future refactoring hazard, and is unlikely to be caught in the Ember test suite itself because the template compiler is loaded differently.