### PR TITLE
Accept `bowerFunnels` as `EmberBuild` option

### DIFF
--- a/lib/bower-tree.js
+++ b/lib/bower-tree.js
@@ -7,23 +7,29 @@ var mergeTrees = require('broccoli-merge-trees');
 // These will be included in the distTrees for use within
 // testsConfig/index.html
 
-var bowerFiles = [
-  new Funnel('config/package_manager_files', {
-    destDir: '/'
-  }),
+module.exports = function getBowerTree(funnels) {
+  if (!funnels) {
+    funnels = {
+      'config/package_manager_files': {
+        destDir: '/'
+      },
 
-  new Funnel('bower_components/qunit/qunit', {
-    destDir: '/qunit'
-  }),
+      'bower_components/qunit/qunit': {
+        destDir: '/qunit'
+      },
 
-  new Funnel('bower_components/jquery/dist', {
-    files: ['jquery.js'],
-    destDir: '/jquery'
-  })
-];
+      'bower_components/jquery/dist': {
+        files: ['jquery.js'],
+        destDir: '/jquery'
+      }
+    };
+  }
+  var bowerFiles = [];
 
-var bowerTree = mergeTrees(bowerFiles);
+  for (var path in funnels) {
+    var funnel = new Funnel(path, funnels[path]);
+    bowerFiles.push(funnel);
+  }
 
-module.exports = function getBowerTree() {
-  return bowerTree;
+  return mergeTrees(bowerFiles);
 };

--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -57,6 +57,7 @@ var EmberBuild = CoreObject.extend({
     this._skipRuntime   = options.skipRuntime;
     this._skipTemplates = options.skipTemplates;
     this._vendoredPackages = options.vendoredPackages;
+    this._bowerTree        = getBowerTree(options.bowerFunnels);
     this._enableSourceMaps = options.hasOwnProperty('enableSourceMaps') ? options.enableSourceMaps : !buildConfig.disableSourceMaps;
 
     this._trees.distTrees = [
@@ -64,7 +65,6 @@ var EmberBuild = CoreObject.extend({
       this._generateCompiledTestsTree,
       this._generateTestingCompiledSourceTree,
       this._getTestConfigTree,
-      this._getBowerTree,
     ];
 
     if (!this._skipTemplates) {
@@ -79,7 +79,6 @@ var EmberBuild = CoreObject.extend({
     ];
   },
 
-  _getBowerTree:              getBowerTree,
   _buildCJSTree:              buildCJSTree,
   _getS3TestRunner:           getS3TestRunner,
   _replaceFeatures:           replaceFeatures,
@@ -283,6 +282,7 @@ var EmberBuild = CoreObject.extend({
       );
     }
 
+    distTrees.push(this._bowerTree);
     distTrees.push(this._buildCJSTree(this._trees.compiledSource, {
       name: this._name,
       namespace: this._namespace


### PR DESCRIPTION
Include `bower_components` in test tree

Pass in bower dependencies so that Ember-Data's tests have access.