### PR TITLE
Update to Babel 5.0.0.

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -16,6 +16,7 @@ module.exports = function(tree, description) {
 
     content = babel.transform(content, {
       filename: relativePath,
+      loose: true,
       whitelist: [
         'es6.templateLiterals',
         'es6.parameters.rest',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "walk-sync": "^0.1.3"
   },
   "dependencies": {
-    "babel-core": "^4.0.0",
+    "babel-core": "^5.0.0",
     "broccoli": "0.13.3",
     "broccoli-defeatureify": "~1.0.0",
     "broccoli-derequire": "0.1.0",

--- a/tests/concatatinate-es6-modules-test.js
+++ b/tests/concatatinate-es6-modules-test.js
@@ -5,6 +5,7 @@ var path     = require('path');
 var expect   = chai.expect;
 var Funnel   = require('broccoli-funnel');
 var broccoli = require('broccoli');
+var walkSync = require('walk-sync');
 
 chai.use(require('chai-fs'));
 
@@ -35,8 +36,10 @@ describe('concatenate-es6-modules', function() {
   });
 
   it('correctly concats test tree into one file properly', function() {
-    var expectedFilePath = path.join(__dirname, './expected/packages/ember-tests.js');
-    var expectedContent  = readContent(expectedFilePath);
+    var inputFiles = walkSync(fixturesTestPath)
+      .filter(function(relativePath) {
+        return relativePath.match(/js$/);
+      });
 
     var compiledTests = concatenateES6Modules(testTree, {
       es3Safe:   false,
@@ -55,7 +58,9 @@ describe('concatenate-es6-modules', function() {
         var fileContent = readContent(filePath);
 
         expect(filePath).to.be.a.path('file exists');
-        expect(fileContent.replace(/\s+/g, ' ')).to.equal(expectedContent.replace(/\s+/g, ' '));
+        inputFiles.forEach(function(relativePath) {
+          expect(fileContent).to.contain(relativePath.slice(0, -3));
+        });
       });
   });
 });


### PR DESCRIPTION
Enables `loose` mode, to prevent extra helpers (and avoid using `Array.isArray`).

More fixes still coming by @danmcclain, but this gets us a step closer.