### PR TITLE
Enable es6.blockScoping for Babel.

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -24,7 +24,8 @@ module.exports = function(tree, description) {
         'es6.destructuring',
         'es6.spread',
         'es6.parameters.default',
-        'es6.properties.shorthand'
+        'es6.properties.shorthand',
+        'es6.blockScoping'
       ]
     }).code;
 


### PR DESCRIPTION
Samples:

```javascript
// input:

for (var i = 0; i < 3; i++) {
  let j = i * i;
  console.log(j);
}
console.log(j); // will throw

// output:
for (var i = 0; i < 3; i++) {
  var _j = i * i;
  console.log(_j);
}
console.log(j); // will throw
```

```javascript
// input:
function f() {
  let j = data.length;
  console.log(j, 'items');
  for (let i = 0; i < j; ++i) {
    let j = data[i] * data[i];
    console.log(j); // squares
  }
}

// output:
function f() {
  var j = data.length;
  console.log(j, 'items');
  for (var i = 0; i < j; ++i) {
    var _j = data[i] * data[i];
    console.log(_j); // squares
  }
}
```