### PR TITLE
Enable es6.properties.computed for Babel

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -38,6 +38,7 @@ module.exports = function(tree, description, options) {
         'es6.destructuring',
         'es6.spread',
         'es6.parameters.default',
+        'es6.properties.computed',
         'es6.properties.shorthand',
         'es6.blockScoping',
         'es6.constants',


### PR DESCRIPTION
Sample

```js
// input:
var prop = "foo";
var o = {
  otherProp: 1,
  [prop]: "bar",
  ['groot'.replace(/o/g,'e')]() {
    console.log("hey there");
  }
};

// output:
var _o;

var prop = "foo";
var o = (_o = {}, _o.otherProp = 1, _o[prop] = "bar", _o["groot".replace(/o/g, "e")] = function () {
  console.log("hey there");
}, _o);
```