### PR TITLE
add support for experimental caching of the ES6 step

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -3,6 +3,15 @@
 var esperanto = require('esperanto');
 var map = require('broccoli-stew').map;
 var babel = require('babel-core');
+var Cache = require('sync-disk-cache');
+var crypto = require('crypto');
+
+var SHOULD_CACHE = process.env.DISK_CACHE;
+var cache = new Cache('emberjs-build-es6');
+
+if (process.env.PURGE_DISK_CACHE) {
+  cache.clear();
+}
 
 module.exports = function(tree, description, options) {
   if (!options) {
@@ -28,6 +37,15 @@ module.exports = function(tree, description, options) {
       moduleName = moduleNames[relativePath] = relativePath.slice(0, -3);
     }
 
+    var key;
+    if (SHOULD_CACHE) {
+      key = hash(content + 0x0 + moduleName);
+
+      if (cache.has(key)) {
+        return cache.get(key).value;
+      }
+    }
+
     content = babel.transform(content, {
       filename: relativePath,
       loose: true,
@@ -45,7 +63,7 @@ module.exports = function(tree, description, options) {
       ]
     }).code;
 
-    return transpiler(content, {
+    content = transpiler(content, {
       amdName: moduleName,
       strict: true,
       _evilES3SafeReExports: true
@@ -54,9 +72,16 @@ module.exports = function(tree, description, options) {
       //sourceMapFile: moduleName + '.map'
     }).code;
 
+    if (SHOULD_CACHE) {
+      cache.set(key, content);
+    }
+    return content;
   });
 
   outputTree.description = 'ES6 Modules' + (description ? ': ' + description : '');
-
   return outputTree;
 };
+
+function hash(string) {
+  return crypto.createHash('md5').update(string).digest('hex');
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "esperanto": "^0.6.15",
     "git-repo-version": "0.3.0",
     "js-string-escape": "^1.0.0",
-    "lodash-node": "^2.4.1"
+    "lodash-node": "^2.4.1",
+    "sync-disk-cache": "0.0.2"
   }
 }


### PR DESCRIPTION
enable it with DISK_CACHE=true
explicitly purge it with PURGE_DISK_CACHE=true

Once a better cache key can be derived, we can try to enable it by default