### PR TITLE
Stop babel deprecation spew for es6.parameters.rest

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -13,11 +13,10 @@ module.exports = function(tree, description, options) {
     nonStandard: false,
     whitelist: [
       'es6.templateLiterals',
-      'es6.parameters.rest',
       'es6.arrowFunctions',
       'es6.destructuring',
       'es6.spread',
-      'es6.parameters.default',
+      'es6.parameters',
       'es6.properties.computed',
       'es6.properties.shorthand',
       'es6.blockScoping',


### PR DESCRIPTION
During ember's own build babel is spewing deprecations. This config change should fix it, but I got blocked in trying to test this due to https://github.com/emberjs/emberjs-build/issues/108