### PR TITLE
Add useStrict to `babel` config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
+node_js:
+  - "iojs"
 
 sudo: false
 

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -12,6 +12,7 @@ module.exports = function(tree, description, options) {
     sourceMaps: config.disableSourceMaps ? false : 'inline',
     nonStandard: false,
     whitelist: [
+      'useStrict',
       'es6.templateLiterals',
       'es6.arrowFunctions',
       'es6.destructuring',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "walk-sync": "^0.1.3"
   },
   "dependencies": {
-    "broccoli": "0.13.3",
+    "broccoli": "0.16.3",
     "broccoli-babel-transpiler": "^5.1.1",
     "broccoli-defeatureify": "~1.0.0",
     "broccoli-derequire": "0.1.0",


### PR DESCRIPTION
This was being done by Esperanto before it was removed, unfortunately we
did not add `"useStrict"` to the whitelist when we removed Esperanto so
we have been running without strict mode since some timeframe in
1.13.0-beta cycle.