### PR TITLE
Automatically resolve relative paths.

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -4,6 +4,32 @@ var transpileES6   = require('broccoli-babel-transpiler');
 var assign = require('lodash-node/modern/objects/assign');
 var config = require('../config/build-config');
 
+// thanks to @chadhietala in amd-name-resolver
+function moduleResolver(child, name) {
+  if (child.charAt(0) !== '.') { return child; }
+
+  var parts = child.split('/');
+  var nameParts = name.split('/');
+  var parentBase = nameParts.slice(0, -1);
+
+  for (var i = 0, l = parts.length; i < l; i++) {
+    var part = parts[i];
+
+    if (part === '..') {
+      if (parentBase.length === 0) {
+        // this is tweaked from amd-name-resolver (it throws there)
+        continue;
+      }
+      parentBase.pop();
+    } else if (part === '.') {
+
+      continue;
+    } else { parentBase.push(part); }
+  }
+
+  return parentBase.join('/');
+}
+
 module.exports = function(tree, description, options) {
   var outputTree = transpileES6(tree, assign({
     loose: true,
@@ -11,6 +37,7 @@ module.exports = function(tree, description, options) {
     modules: 'amdStrict',
     sourceMaps: config.disableSourceMaps ? false : 'inline',
     nonStandard: false,
+    resolveModuleSource: moduleResolver,
     whitelist: [
       'useStrict',
       'es6.templateLiterals',


### PR DESCRIPTION
Inlines @chadhietala's amd-name-resolver with a small tweak, to prevent an error from being thrown in the case where `../` is used from a top level module.  That is intentionally done in HTMLBars to allow cross package requires in CJS modules. It may be possible to fix/change that upstream, but that work should not block this...