### PR TITLE
Remove broccoli-use-strict-remover in favor of Babel plugin.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -7,7 +7,6 @@ var writeFile        = require('broccoli-file-creator');
 var derequire        = require('broccoli-derequire');
 var mergeTrees       = require('broccoli-merge-trees');
 var transpileES6     = require('./utils/transpile-es6');
-var useStrictRemover = require('broccoli-use-strict-remover');
 
 var debug               = require('./utils/debug-tree');
 var buildConfig         = require('./config/build-config');
@@ -47,8 +46,6 @@ module.exports = function concatenateES6Modules(inputTrees, options) {
   sourceTrees = transpileES6(sourceTrees, options.description, {
     plugins: options.babel ? options.babel.plugins : []
   });
-
-  sourceTrees = useStrictRemover(sourceTrees);
 
   var concatTrees = [loader, mergedOptions.generators, iifeStart, iifeStop, sourceTrees];
   if (mergedOptions.includeLoader) {

--- a/lib/utils/conditional-use-strict-babel-plugin.js
+++ b/lib/utils/conditional-use-strict-babel-plugin.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var THIS_BREAK_KEYS = ['FunctionExpression', 'FunctionDeclaration', 'ClassProperty'];
+
+module.exports = function(babel) {
+  var t = babel.types;
+
+  function isStrictDirective(node) {
+    if (!t.isLiteral(node)) {
+      return false;
+    }
+
+    var value;
+    if (node.raw && node.rawValue === node.value) {
+      value = node.rawValue;
+    } else {
+      value = node.value;
+    }
+
+    return value === 'use strict' || value === 'no use strict';
+  }
+
+  return new babel.Plugin('conditional-use-strict', {
+    visitor: {
+      Program: {
+        enter: function(program) {
+          var first = program.body[0];
+
+          var directive;
+          if (t.isExpressionStatement(first) && isStrictDirective(first.expression)) {
+            directive = first;
+          } else {
+            directive = t.expressionStatement(t.literal('use strict'));
+            this.unshiftContainer('body', directive);
+            if (first) {
+              directive.leadingComments = first.leadingComments;
+              first.leadingComments = [];
+            }
+          }
+          directive._blockHoist = Infinity;
+        }
+      },
+
+      ThisExpression: function() {
+        var foundParent = this.findParent(function(path) {
+          return !path.is('shadow') && THIS_BREAK_KEYS.indexOf(path.type) >= 0;
+        });
+
+        if (!foundParent){
+          return t.identifier('undefined');
+        }
+      }
+    }
+  });
+};

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -3,6 +3,7 @@
 var transpileES6   = require('broccoli-babel-transpiler');
 var assign = require('lodash-node/modern/objects/assign');
 var config = require('../config/build-config');
+var conditionalUseStrict = require('./conditional-use-strict-babel-plugin');
 
 // thanks to @chadhietala in amd-name-resolver
 function moduleResolver(child, name) {
@@ -30,8 +31,8 @@ function moduleResolver(child, name) {
   return parentBase.join('/');
 }
 
-module.exports = function(tree, description, options) {
-  var outputTree = transpileES6(tree, assign({
+module.exports = function(tree, description, _options) {
+  var options = assign({
     loose: true,
     moduleId: true,
     modules: 'amdStrict',
@@ -39,7 +40,6 @@ module.exports = function(tree, description, options) {
     nonStandard: false,
     resolveModuleSource: moduleResolver,
     whitelist: [
-      'useStrict',
       'es6.templateLiterals',
       'es6.arrowFunctions',
       'es6.destructuring',
@@ -51,8 +51,18 @@ module.exports = function(tree, description, options) {
       'es6.constants',
       'es6.modules'
     ]
-  }, options));
+  }, _options);
 
+  if (!options.plugins) {
+    options.plugins = [];
+  } else {
+    // avoid sharing the plugins list
+    options.plugins = options.plugins.slice();
+  }
+
+  options.plugins.push(conditionalUseStrict);
+
+  var outputTree = transpileES6(tree, options);
   if (description) {
     outputTree.description = description;
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "broccoli-stew": "^0.3.5",
     "broccoli-string-replace": "0.1.0",
     "broccoli-uglify-sourcemap": "^1.0.1",
-    "broccoli-use-strict-remover": "^1.0.0",
     "core-object": "0.0.4",
     "ember-cli-yuidoc": "0.3.1",
     "git-repo-version": "0.3.0",

--- a/tests/fixtures/transpile-es6/conditional-use-strict/with-no-use-strict-directive.js
+++ b/tests/fixtures/transpile-es6/conditional-use-strict/with-no-use-strict-directive.js
@@ -1,0 +1,3 @@
+"no use strict";
+
+function nothingHere() { }

--- a/tests/fixtures/transpile-es6/conditional-use-strict/with-use-strict-directive.js
+++ b/tests/fixtures/transpile-es6/conditional-use-strict/with-use-strict-directive.js
@@ -1,0 +1,3 @@
+"use strict";
+
+function nothingHere() { }

--- a/tests/fixtures/transpile-es6/conditional-use-strict/without-directive.js
+++ b/tests/fixtures/transpile-es6/conditional-use-strict/without-directive.js
@@ -1,0 +1,1 @@
+function nothingHere() { }

--- a/tests/utils/transpile-es6-test.js
+++ b/tests/utils/transpile-es6-test.js
@@ -35,4 +35,31 @@ describe('transpileES6', function() {
         expect(fileContent).not.to.contain('=>');
       });
   });
+
+  it('does not add `use strict` if `no use strict` directive is present', function() {
+    var strictDirectiveFixture = path.join(transpileFixtures, 'conditional-use-strict');
+
+    var tree = transpileES6(strictDirectiveFixture);
+
+    builder = new broccoli.Builder(tree);
+
+    return builder.build()
+      .then(function(results) {
+        expect(
+          readContent(results.directory + '/without-directive.js')
+        ).to.match(/['"]use strict['"];/);
+
+        expect(
+          readContent(results.directory + '/with-no-use-strict-directive.js')
+        ).not.to.match(/['"]use strict['"];/);
+
+        expect(
+          readContent(results.directory + '/with-no-use-strict-directive.js')
+        ).to.match(/['"]no use strict['"];/);
+
+        expect(
+          readContent(results.directory + '/with-use-strict-directive.js')
+        ).to.match(/['"]use strict['"];/);
+      });
+  });
 });


### PR DESCRIPTION
Copy the Babel internal `useStrict` plugin and modify slightly for our needs.