### PR TITLE
Remove derequire step via customization of AMD formatter.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -4,21 +4,16 @@ var merge            = require('lodash-node/modern/objects/merge');
 var util             = require('util');
 var concat           = require('broccoli-sourcemap-concat');
 var writeFile        = require('broccoli-file-creator');
-var derequire        = require('broccoli-derequire');
 var mergeTrees       = require('broccoli-merge-trees');
 var transpileES6     = require('./utils/transpile-es6');
 
 var debug               = require('./utils/debug-tree');
-var buildConfig         = require('./config/build-config');
 var getVendoredPackages = require('./get-vendored-packages');
-
-var disableDerequire    = buildConfig.disableDerequire;
 
 var iifeStart = writeFile('iife-start', '(function() {');
 var iifeStop  = writeFile('iife-stop', '})();');
 
 var defaultOptions = {
-  derequire:  !buildConfig.isDevelopment,
   inputFiles: ['**/*.js'],
   generators: 'generators'
 };
@@ -88,10 +83,6 @@ module.exports = function concatenateES6Modules(inputTrees, options) {
     allowNone: true,
     description: 'Concat ES6: ' + destFile
   });
-
-  if (mergedOptions.derequire && !disableDerequire) {
-    concattedES6 = derequire(concattedES6);
-  }
 
   return concattedES6;
 };

--- a/lib/config/build-config.js
+++ b/lib/config/build-config.js
@@ -1,9 +1,9 @@
 'use strict';
 
-// To create fast production builds (without minification, derequire, or JSHint)
+// To create fast production builds (without minification, JSCS, or JSHint)
 // run the following:
 //
-// DISABLE_JSHINT=true DISABLE_MIN=true DISABLE_DEREQUIRE=true ember serve --environment=production
+// DISABLE_JSHINT=true DISABLE_JSCS=true DISABLE_MIN=true ember serve --environment=production
 
 var env           = process.env.EMBER_ENV || 'development';
 var isDevelopment = env === 'development';
@@ -14,8 +14,6 @@ var disableMin    = !!process.env.DISABLE_MIN || false;
 var enableDocs    = !!process.env.ENABLE_DOCS || false;
 
 var enableTreeDebugging = !!process.env.ENABLE_TREE_DEBUGGING || false;
-
-var disableDerequire = !!process.env.DISABLE_DEREQUIRE || false;
 
 // We must increase the maxTickDepth in order to prevent errors from node
 process.maxTickDepth = 2000;
@@ -34,7 +32,6 @@ module.exports = {
   disableJSCS:         disableJSCS,
   disableMin:          disableMin,
   enableDocs:          enableDocs,
-  disableDerequire:    disableDerequire,
   enableTreeDebugging: enableTreeDebugging,
   disableSourceMaps:   disableSourceMaps,
 };

--- a/lib/utils/babel-enifed-module-formatter.js
+++ b/lib/utils/babel-enifed-module-formatter.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function(babel) {
+  var t = babel.types;
+
+  return new babel.Plugin('define-to-enifed', {
+    visitor: {
+      CallExpression: function(node){
+        if (t.isIdentifier(node.callee, {name: 'define'})){
+          node.callee = t.identifier('enifed');
+        }
+      },
+      BlockStatement: function(){
+        this.skip();
+      }
+    }
+  });
+};

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -4,6 +4,7 @@ var transpileES6   = require('broccoli-babel-transpiler');
 var assign = require('lodash-node/modern/objects/assign');
 var config = require('../config/build-config');
 var conditionalUseStrict = require('./conditional-use-strict-babel-plugin');
+var enifedFormatter = require('./babel-enifed-module-formatter');
 
 // thanks to @chadhietala in amd-name-resolver
 function moduleResolver(child, name) {
@@ -61,6 +62,7 @@ module.exports = function(tree, description, _options) {
   }
 
   options.plugins.push(conditionalUseStrict);
+  options.plugins.push({ transformer: enifedFormatter, position: 'after' });
 
   var outputTree = transpileES6(tree, options);
   if (description) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "broccoli": "0.16.3",
     "broccoli-babel-transpiler": "^5.4.5",
-    "broccoli-derequire": "0.1.0",
     "broccoli-es3-safe-recast": "1.0.0",
     "broccoli-file-creator": "^1.0.0",
     "broccoli-funnel": "^0.2.7",

--- a/tests/concatatinate-es6-modules-test.js
+++ b/tests/concatatinate-es6-modules-test.js
@@ -43,7 +43,6 @@ describe('concatenate-es6-modules', function() {
 
     var compiledTests = concatenateES6Modules(testTree, {
       es3Safe:   false,
-      derequire: false,
       includeLoader: true,
       destFile: '/ember-tests.js',
       generators: generatorsPath,

--- a/tests/config/build-config-test.js
+++ b/tests/config/build-config-test.js
@@ -12,7 +12,6 @@ describe('build config', function() {
       disableJSCS:         false,
       disableMin:          false,
       enableDocs:          false,
-      disableDerequire:    false,
       enableTreeDebugging: false,
       disableSourceMaps:   false,
     });


### PR DESCRIPTION
This is a bit of a hack, but proper support has been PR'ed upstream and is awaiting feedback. Hopefully, when that lands we can simply specify the `defineId` option and remove this horrible plugin.

In the meantime, I think we should move ahead. This shaves another 3-5 seconds off of warm boot on a production build (from 19s down to 15s).