### PR TITLE
Remove unneeded tree manipulation.

### DIFF
--- a/lib/es6-vendored-package.js
+++ b/lib/es6-vendored-package.js
@@ -24,13 +24,6 @@ module.exports = function vendoredES6Package(packageName, opts) {
   var options = opts || {};
 
   var tree = new Funnel(options.libPath || 'bower_components/' + packageName + '/lib', {
-    getDestinationPath: function(relativePath) {
-      if (relativePath === 'main.js') {
-        return packageName + '.js';
-      }
-
-      return relativePath;
-    },
     destDir: '/'
   });
 

--- a/lib/vendored-package.js
+++ b/lib/vendored-package.js
@@ -3,10 +3,9 @@
 var Funnel      = require('broccoli-funnel');
 
 /*
-  Returns a tree picked from `packages/#{packageName}/lib`
-  and then move `main.js` to `/#{packageName}.js`.
+  Returns a tree picked from `packages/#{packageName}/lib`.
 
-  This method is used for `handlebars` and `loader`.
+  This method is used for `loader`.
 */
 module.exports = function vendoredPackage(packageName, opts) {
   var options = opts || {};
@@ -18,19 +17,12 @@ module.exports = function vendoredPackage(packageName, opts) {
       Given the following dir:
         /packages/metamorph
           └── lib
-            └── main.js
+            └── index.js
       Then tree would be:
         /metamorph
-          └── metamorph.js
+          └── index.js
    */
   return new Funnel(libPath, {
-    getDestinationPath: function(relativePath) {
-      if (relativePath === 'main.js') {
-        return packageName + '.js';
-      }
-
-      return relativePath;
-    },
     destDir: '/'
   });
 };

--- a/tests/vendored-package-test.js
+++ b/tests/vendored-package-test.js
@@ -38,7 +38,7 @@ describe('vendored-package', function() {
       .then(function(results) {
         var outputPath = results.directory;
 
-        expect(walkSync(outputPath)).to.deep.equal(['loader.js']);
+        expect(walkSync(outputPath)).to.deep.equal(['index.js']);
       });
   });
 });


### PR DESCRIPTION
We no longer need to muck with the custom destination paths here.