### PR TITLE
Remove IIFE negation

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -185,6 +185,7 @@ var EmberBuild = CoreObject.extend({
   _generateMinifiedCompiledSourceTree: function generateMinifiedCompiledSourceTree() {
     return this._trees.minCompiledSource = this._minifySourceTree(this._trees.prodCompiledSource, {
       enableSourceMaps: this._enableSourceMaps,
+      negateIIFE: false,
       srcFile:  this._name + '.prod.js',
       destFile: this._name + '.min.js',
       mangle:   true,

--- a/lib/minify-source-tree.js
+++ b/lib/minify-source-tree.js
@@ -30,6 +30,7 @@ module.exports = function minifySourceTree(tree, options) {
     sourceMapConfig: {
       enabled: options.enableSourceMaps
     },
+    negate_iife: options.negateIIFE, // jshint ignore:line
     mangle:   options.mangle,
     compress: options.compress
   });


### PR DESCRIPTION
V8 heuristics around IIFE's is pretty narrow and only eagerly compiles
and parses IIFEs if they begin with a paren. When iife negation is
turned on in uglify, it removes the parens and replaces them with the !
IIFE syntax which causes V8 to lazily parse functions that are meant to
be eager. Adding this flag opts out of the ! IIFE transform. @krisselden
is also opening an issue on the uglify project to change the default.

Currently you will notice that on V8, prod builds will parse/eval faster
than min builds... which is bonkers.

Reference:
https://github.com/v8/v8/blob/master/src/parsing/parser.cc#L4272-L4307