### PR TITLE
Transpile __proto__ to assign

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -52,7 +52,8 @@ module.exports = function(tree, description, _options) {
       'es6.blockScoping',
       'es6.constants',
       'es6.modules',
-      'es6.classes'
+      'es6.classes',
+      'spec.protoToAssign'
     ]
   }, _options);
 

--- a/tests/fixtures/transpile-es6/classes/some-file.js
+++ b/tests/fixtures/transpile-es6/classes/some-file.js
@@ -1,0 +1,23 @@
+class A {
+  static foo() {
+    return "foo";
+  }
+
+  bar() {
+    return "bar";
+  }
+
+  foobar() {
+    return this.constructor.foo() + this.bar();
+  }
+}
+
+class B extends A {
+  baz() {
+    return "baz";
+  }
+
+  foobarbaz() {
+    return this.foobar() + this.baz();
+  }
+}

--- a/tests/utils/transpile-es6-test.js
+++ b/tests/utils/transpile-es6-test.js
@@ -36,6 +36,31 @@ describe('transpileES6', function() {
       });
   });
 
+  it('correctly transpile classes', function() {
+    var classesFixture = path.join(transpileFixtures, 'classes');
+
+    var tree = transpileES6(classesFixture);
+
+    builder = new broccoli.Builder(tree);
+
+    return builder.build()
+      .then(function(results) {
+        var filePath = results.directory + '/some-file.js';
+        var fileContent = readContent(filePath);
+
+        expect(fileContent).not.to.contain('class A');
+
+        // Ensure Babel has inserted its class helpers
+        // TODO: flip this assertion when switching to global helpers
+        expect(fileContent).to.contain('_inherits');
+        expect(fileContent).to.contain('_classCallCheck');
+
+        // IE <= 10 does not support __proto__, so we cannot use it for statics
+        expect(fileContent).not.to.contain('__proto__');
+        expect(fileContent).to.contain('_defaults');
+      });
+  });
+
   it('does not add `use strict` if `no use strict` directive is present', function() {
     var strictDirectiveFixture = path.join(transpileFixtures, 'conditional-use-strict');
 


### PR DESCRIPTION
By default, Babel sets `__proto__` to make static inheritance work.
However, this does not work in IE <= 10, so we need to transpile that
into ~= `Object.assign(...)`. This requires you to not change the static
functions/members once inherited, but that should be fine for us.