### PR TITLE
Fix prod builds using testVendorTrees.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -165,6 +165,7 @@ var EmberBuild = CoreObject.extend({
     return this._trees.prodCompiledTests = this._concatenateES6Modules(buildTree.testTree, {
       babel:         this._babelConfig.production,
       destFile:      '/' + this._name + '-tests.prod.js',
+      vendorTrees:   buildTree.testVendorTrees,
       includeLoader: true
     });
   },


### PR DESCRIPTION
The ember-tests.js file already includes the testVendorTrees, but when that was added I forgot to also update ember-tests.prod.js too.

:(