### PR TITLE
Add preparse optimization

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -7,6 +7,7 @@ var replace      = require('broccoli-string-replace');
 var mergeTrees   = require('broccoli-merge-trees');
 var yuidocPlugin = require('ember-cli-yuidoc');
 var CoreObject   = require('core-object');
+var preparse     = require('broccoli-ember-preparse');
 
 var debug                  = require('./utils/debug-tree');
 var es6Package             = require('./get-es6-package');
@@ -104,7 +105,9 @@ var EmberBuild = CoreObject.extend({
       bootstrapModule: this._name
     });
 
-    return this._trees.compiledSource = debug(compiledSource, 'compiled-source');
+    compiledSource = debug(compiledSource, 'compiled-source');
+
+    return this._trees.compiledSource = preparse(compiledSource, this._vendoredPackages.loader);
   },
 
   // Generates prod build. Defeatureify increases the overall runtime speed of ember.js by ~10%.
@@ -120,7 +123,7 @@ var EmberBuild = CoreObject.extend({
       bootstrapModule: this._name
     });
 
-    return this._trees.prodCompiledSource = prodTree;
+    return this._trees.prodCompiledSource = preparse(prodTree, this._vendoredPackages.loader);
   },
 
   _generateDeprecatedDebugFileTree: function generateDeprecatedDebugFileTree() {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "broccoli": "0.16.3",
     "broccoli-babel-transpiler": "^5.4.5",
     "broccoli-concat": "^2.0.0",
+    "broccoli-ember-preparse": "0.0.2",
     "broccoli-file-creator": "^1.0.0",
     "broccoli-funnel": "^1.0.1",
     "broccoli-jscs": "^1.0.0",

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -91,6 +91,10 @@ describe('ember-build', function() {
           'ember-htmlbars-template-compiler': {}
         }
       });
+
+      emberBuild._vendoredPackages = {
+        loader: {}
+      };
     });
 
     after(function() {

--- a/tests/helpers/ensure-method-returns-tree.js
+++ b/tests/helpers/ensure-method-returns-tree.js
@@ -13,10 +13,14 @@ module.exports = function ensureMethodReturnsTree(methodName) {
 
     before(function() {
       emberBuild._trees.prodCompiledSource = {};
+      emberBuild._vendoredPackages = {
+        loader: {}
+      };
     });
 
     after(function() {
       emberBuild._trees.prodCompiledSource = null;
+      emberBuild._vendoredPackages = null;
     });
 
     it('should return a tree to prevent build failures', function() {


### PR DESCRIPTION
Wanted to get the ball rolling on integrating [broccoli-ember-preparse](https://www.npmjs.com/package/broccoli-ember-preparse) into the build. Preparse re-writes define statements as immediately executing functions for internal ember modules that have to be evaluated up front. This shaves off the overhead of lazily defining modules that don't need to be lazy. We're seeing about a 300ms boost on an older android phone on app boot.

This is at a POC stage. There are a few hacks:

- Wherever there is a direct require statement, the [dependency has to be manually declared](https://github.com/asakusuma/broccoli-ember-preparse/blob/master/lib/define-rewriter/src/process-ember.js#L54).
- The loader is hardcoded right now. Would be nice if it was actually pulled in the [ember loader](https://github.com/emberjs/ember.js/blob/master/packages/loader/lib/index.js). This is not possible in it's current state without doing some ast-rewriting magic. The [plumbing exists](https://github.com/asakusuma/broccoli-ember-preparse/blob/master/lib/define-rewriter/src/index.js#L47) for supplying the loader file to be used by preparse, but it's not actually being used right now.

@stefanpenner @krisselden @rwjblue @chadhietala 