### PR TITLE
disable sourcemaps until they are fixed

### DIFF
--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -38,7 +38,8 @@ module.exports = function(tree, description, _options) {
     moduleId: true,
     modules: 'amdStrict',
     avoidDefine: true,
-    sourceMaps: config.disableSourceMaps ? false : 'inline',
+    // until we fix them, we should just turn of high fedility sourcemaps
+    sourceMaps: false, //config.disableSourceMaps ? false : 'inline',
     nonStandard: false,
     resolveModuleSource: moduleResolver,
     whitelist: [


### PR DESCRIPTION
We may want to offer higher control the binary on/off.

Likely should offer the following:
- concatSourceMaps
- babel/transpiler sourceMaps

Will revisit tonight.
