### PR TITLE
Make precompiler dependent on package being precompiled.

### DIFF
--- a/lib/get-es6-package.js
+++ b/lib/get-es6-package.js
@@ -104,11 +104,14 @@ function getES6Package(packages, packageName, opts) {
       template functions.  This is done so that HTMLBars compiler is
       not required for running Ember.
     */
-    libTree = htmlbarsTemplatePrecompiler(libTree, {
-      htmlbars: options.htmlbars
-    });
 
-    libTree = glimmerTemplatePrecompiler(libTree);
+    if (packageName.indexOf('htmlbars') > -1) {
+      libTree = htmlbarsTemplatePrecompiler(libTree, {
+        htmlbars: options.htmlbars
+      });
+    } else if (packageName.indexOf('glimmer') > -1) {
+      libTree = glimmerTemplatePrecompiler(libTree);
+    }
   }
 
   var testTree = new Funnel(options.testPath || 'packages/' + packageName + '/tests', {

--- a/lib/utils/glimmer-template-precompiler.js
+++ b/lib/utils/glimmer-template-precompiler.js
@@ -17,7 +17,7 @@ function GlimmerTemplatePrecompiler (inputTree) {
   this.inputTree = inputTree;
 }
 
-GlimmerTemplatePrecompiler.prototype.extensions = ['_ghbs'];
+GlimmerTemplatePrecompiler.prototype.extensions = ['hbs'];
 GlimmerTemplatePrecompiler.prototype.targetExtension = 'js';
 
 GlimmerTemplatePrecompiler.prototype.baseDir = function() {


### PR DESCRIPTION
Allows HTMLBars precompiler for `ember-htmlbars` templates, and `glimmer-engine` precompiler for `ember-glimmer` templates.