### PR TITLE
Actually pass through options.vendorPackages

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -151,6 +151,7 @@ var EmberBuild = CoreObject.extend({
       babel:         this._babelConfig.development,
       destFile:      '/' + this._name + '-tests.js',
       vendorTrees:     buildTree.testVendorTrees,
+      vendoredPackages: this._vendoredPackages,
       includeLoader: true
     });
   },
@@ -176,6 +177,7 @@ var EmberBuild = CoreObject.extend({
       babel:         this._babelConfig.development,
       destFile:      '/' + this._name + '-testing.js',
       includeLoader: true,
+      vendoredPackages: this._vendoredPackages,
       bootstrapModule: this._name + '-testing'
     });
   },

--- a/lib/get-build-runtime-tree.js
+++ b/lib/get-build-runtime-tree.js
@@ -41,6 +41,7 @@ module.exports = function buildRuntimeTree(packages, _vendoredPackages, _options
     includeLoader: true,
     moduleExportDefault: 'ember-runtime',
     vendorTrees: mergeTrees(runtimeVendorTrees),
+    vendoredPackages: vendoredPackages,
     destFile: '/ember-runtime.js'
   });
 };

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -40,6 +40,7 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
     bootstrapModules: ['ember-environment', 'ember-debug'],
     moduleExport: 'ember-template-compiler',
     vendorTrees: mergeTrees(vendorTrees, {overwrite: true}),
+    vendoredPackages: vendoredPackages,
     destFile: '/ember-template-compiler.js'
   });
 };


### PR DESCRIPTION
Actually pass through options.vendorPackages in all cases, so that getVendoredPackages() isn't used when this is passed in.