### PR TITLE
Build infra changes for splitting the template compilers

### DIFF
--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -23,17 +23,28 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
   es6Package(packages, 'ember-metal');
   es6Package(packages, 'ember-debug');
   es6Package(packages, 'ember-template-compiler');
+  es6Package(packages, 'ember-htmlbars-template-compiler');
 
   var trees = [
     packages['ember-template-compiler'].trees.lib,
     packages['ember-debug'].trees.lib,
     packages['ember-console'].trees.lib,
     packages['ember-environment'].trees.lib,
+    packages['ember-htmlbars-template-compiler'].trees.lib,
     createEmberVersion(),
     compileEmberFeatures()
   ];
 
-  var templateCompilerVendor = packages['ember-template-compiler'].templateCompilerVendor || [];
+   var templateCompilerVendor = packages['ember-template-compiler'].templateCompilerVendor || [];
+
+   templateCompilerVendor = templateCompilerVendor.concat(packages['ember-htmlbars-template-compiler'].templateCompilerVendor || []);
+
+  if (packages['ember-glimmer-template-compiler']) {
+    es6Package(packages, 'ember-glimmer-template-compiler');
+    trees.push(packages['ember-glimmer-template-compiler'].trees.lib);
+    templateCompilerVendor = templateCompilerVendor.concat(packages['ember-glimmer-template-compiler'].templateCompilerVendor);
+  }
+
   var vendorTrees = templateCompilerVendor.map(function(req){ return vendoredPackages[req];});
 
   trees.push(packages['ember-metal'].trees.lib);

--- a/lib/utils/glimmer-template-precompiler.js
+++ b/lib/utils/glimmer-template-precompiler.js
@@ -26,7 +26,7 @@ GlimmerTemplatePrecompiler.prototype.baseDir = function() {
 
 GlimmerTemplatePrecompiler.prototype.processString = function(content) {
   var compiledSpec = compile(content);
-  var template = 'import template from "ember-glimmer/ember-template-compiler/system/template";\n';
+  var template = 'import { template } from "ember-glimmer-template-compiler";\n';
   template += 'export default template(' + JSON.stringify(compiledSpec) + ');';
 
   return template;

--- a/lib/utils/htmlbars-template-precompiler.js
+++ b/lib/utils/htmlbars-template-precompiler.js
@@ -38,7 +38,7 @@ EmberTemplatePrecompiler.prototype.processString = function(content) {
   };
 
   var compiledSpec = this.htmlbarsCompiler(content, compileOptions);
-  var template = 'import template from "ember-template-compiler/system/template";\n';
+  var template = 'import { template } from "ember-htmlbars-template-compiler";\n';
   template += 'export default template(' + compiledSpec + ');';
 
   return template;

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -87,7 +87,8 @@ describe('ember-build', function() {
           'ember-console': { skipTests: true },
           'ember-runtime': { vendorRequirements: [], requirements: []},
           'ember-debug': {},
-          'ember-template-compiler': {}
+          'ember-template-compiler': {},
+          'ember-htmlbars-template-compiler': {}
         }
       });
     });


### PR DESCRIPTION
This just bundles both template compilers if they are both present.