### PR TITLE
Remove ember-template-compiler packages from ember.*.js.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -241,7 +241,7 @@ var EmberBuild = CoreObject.extend({
         });
       }
 
-      if (currentPackage.trees.lib) {
+      if (!currentPackage.templateCompilerOnly && currentPackage.trees.lib) {
         devSourceTrees.push(currentPackage.trees.lib);
 
         if (currentPackage.developmentOnly) {

--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -24,12 +24,14 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
   es6Package(packages, 'ember-debug');
   es6Package(packages, 'ember-template-compiler');
   es6Package(packages, 'ember-htmlbars-template-compiler');
+  es6Package(packages, 'ember-templates');
 
   var trees = [
     packages['ember-template-compiler'].trees.lib,
     packages['ember-debug'].trees.lib,
     packages['ember-console'].trees.lib,
     packages['ember-environment'].trees.lib,
+    packages['ember-templates'].trees.lib,
     packages['ember-htmlbars-template-compiler'].trees.lib,
     createEmberVersion(),
     compileEmberFeatures()

--- a/lib/utils/glimmer-template-precompiler.js
+++ b/lib/utils/glimmer-template-precompiler.js
@@ -24,7 +24,7 @@ GlimmerTemplatePrecompiler.prototype.baseDir = function() {
 
 GlimmerTemplatePrecompiler.prototype.processString = function(content) {
   var compiledSpec = compile(content);
-  var template = 'import { template } from "ember-glimmer-template-compiler";\n';
+  var template = 'import { template } from "ember-glimmer";\n';
   template += 'export default template(' + JSON.stringify(compiledSpec) + ');';
 
   return template;

--- a/lib/utils/htmlbars-template-precompiler.js
+++ b/lib/utils/htmlbars-template-precompiler.js
@@ -36,7 +36,7 @@ EmberTemplatePrecompiler.prototype.processString = function(content) {
   };
 
   var compiledSpec = this.htmlbarsCompiler(content, compileOptions);
-  var template = 'import { template } from "ember-htmlbars-template-compiler";\n';
+  var template = 'import { template } from "ember-htmlbars";\n';
   template += 'export default template(' + compiledSpec + ');';
 
   return template;

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -88,7 +88,8 @@ describe('ember-build', function() {
           'ember-runtime': { vendorRequirements: [], requirements: []},
           'ember-debug': {},
           'ember-template-compiler': {},
-          'ember-htmlbars-template-compiler': {}
+          'ember-htmlbars-template-compiler': {},
+          'ember-templates': {}
         }
       });
     });

--- a/tests/expected/concat-tests/ember-tests.js
+++ b/tests/expected/concat-tests/ember-tests.js
@@ -1,6 +1,19 @@
 ;(function() {
 
 
+enifed("ember-metal", ["exports"], function (exports) {
+  "use strict";
+});
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsImZpbGUiOiJlbWJlci1tZXRhbC5qcyIsInNvdXJjZXNDb250ZW50IjpbXX0=
+enifed('ember-metal.jshint', ['exports'], function (exports) {
+  'use strict';
+
+  module('JSHint - .');
+  test('ember-metal.js should pass jshint', function () {
+    ok(true, 'ember-metal.js should pass jshint.');
+  });
+});
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtYmVyLW1ldGFsLmpzaGludC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7QUFBQSxRQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7QUFDckIsTUFBSSxDQUFDLG1DQUFtQyxFQUFFLFlBQVc7QUFDbkQsTUFBRSxDQUFDLElBQUksRUFBRSxvQ0FBb0MsQ0FBQyxDQUFDO0dBQ2hELENBQUMsQ0FBQyIsImZpbGUiOiJlbWJlci1tZXRhbC5qc2hpbnQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUoJ0pTSGludCAtIC4nKTtcbnRlc3QoJ2VtYmVyLW1ldGFsLmpzIHNob3VsZCBwYXNzIGpzaGludCcsIGZ1bmN0aW9uKCkgeyBcbiAgb2sodHJ1ZSwgJ2VtYmVyLW1ldGFsLmpzIHNob3VsZCBwYXNzIGpzaGludC4nKTsgXG59KTtcbiJdfQ==
 enifed("ember-metal/alias", ["exports"], function (exports) {
   "use strict";
 });
@@ -125,17 +138,4 @@ enifed('ember-metal/tests/streams/simple_test.jshint', ['exports'], function (ex
   });
 });
 //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtYmVyLW1ldGFsL3Rlc3RzL3N0cmVhbXMvc2ltcGxlX3Rlc3QuanNoaW50LmpzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7OztBQUFBLFFBQU0sQ0FBQyxvQ0FBb0MsQ0FBQyxDQUFDO0FBQzdDLE1BQUksQ0FBQyw2REFBNkQsRUFBRSxZQUFXO0FBQzdFLE1BQUUsQ0FBQyxJQUFJLEVBQUUsOERBQThELENBQUMsQ0FBQztHQUMxRSxDQUFDLENBQUMiLCJmaWxlIjoiZW1iZXItbWV0YWwvdGVzdHMvc3RyZWFtcy9zaW1wbGVfdGVzdC5qc2hpbnQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUoJ0pTSGludCAtIGVtYmVyLW1ldGFsL3Rlc3RzL3N0cmVhbXMnKTtcbnRlc3QoJ2VtYmVyLW1ldGFsL3Rlc3RzL3N0cmVhbXMvc2ltcGxlX3Rlc3QuanMgc2hvdWxkIHBhc3MganNoaW50JywgZnVuY3Rpb24oKSB7IFxuICBvayh0cnVlLCAnZW1iZXItbWV0YWwvdGVzdHMvc3RyZWFtcy9zaW1wbGVfdGVzdC5qcyBzaG91bGQgcGFzcyBqc2hpbnQuJyk7IFxufSk7XG4iXX0=
-enifed("ember-metal", ["exports"], function (exports) {
-  "use strict";
-});
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IiIsImZpbGUiOiJlbWJlci1tZXRhbC5qcyIsInNvdXJjZXNDb250ZW50IjpbXX0=
-enifed('ember-metal.jshint', ['exports'], function (exports) {
-  'use strict';
-
-  module('JSHint - .');
-  test('ember-metal.js should pass jshint', function () {
-    ok(true, 'ember-metal.js should pass jshint.');
-  });
-});
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImVtYmVyLW1ldGFsLmpzaGludC5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOzs7QUFBQSxRQUFNLENBQUMsWUFBWSxDQUFDLENBQUM7QUFDckIsTUFBSSxDQUFDLG1DQUFtQyxFQUFFLFlBQVc7QUFDbkQsTUFBRSxDQUFDLElBQUksRUFBRSxvQ0FBb0MsQ0FBQyxDQUFDO0dBQ2hELENBQUMsQ0FBQyIsImZpbGUiOiJlbWJlci1tZXRhbC5qc2hpbnQuanMiLCJzb3VyY2VzQ29udGVudCI6WyJtb2R1bGUoJ0pTSGludCAtIC4nKTtcbnRlc3QoJ2VtYmVyLW1ldGFsLmpzIHNob3VsZCBwYXNzIGpzaGludCcsIGZ1bmN0aW9uKCkgeyBcbiAgb2sodHJ1ZSwgJ2VtYmVyLW1ldGFsLmpzIHNob3VsZCBwYXNzIGpzaGludC4nKTsgXG59KTtcbiJdfQ==
 }());

--- a/tests/get-es6-package-test.js
+++ b/tests/get-es6-package-test.js
@@ -81,6 +81,8 @@ describe('get-es6-package', function() {
         var outputPath = results.directory;
 
         expect(walkSync(outputPath)).to.deep.equal([
+          'ember-metal.jscs-test.js',
+          'ember-metal.jshint.js',
           'ember-metal/',
           'ember-metal/alias.jscs-test.js',
           'ember-metal/alias.jshint.js',
@@ -104,9 +106,7 @@ describe('get-es6-package', function() {
           'ember-metal/tests/streams/',
           'ember-metal/tests/streams/simple_test.js',
           'ember-metal/tests/streams/simple_test.jscs-test.js',
-          'ember-metal/tests/streams/simple_test.jshint.js',
-          'ember-metal.jscs-test.js',
-          'ember-metal.jshint.js'
+          'ember-metal/tests/streams/simple_test.jshint.js'
         ]);
       });
   });
@@ -193,6 +193,7 @@ describe('get-es6-package', function() {
         var outputPath = results.directory;
 
         expect(walkSync(outputPath)).to.deep.equal([
+          'htmlbars-util.js',
           'htmlbars-util/',
           'htmlbars-util/array-utils.js',
           'htmlbars-util/handlebars/',
@@ -201,8 +202,7 @@ describe('get-es6-package', function() {
           'htmlbars-util/namespaces.js',
           'htmlbars-util/object-utils.js',
           'htmlbars-util/quoting.js',
-          'htmlbars-util/safe-string.js',
-          'htmlbars-util.js'
+          'htmlbars-util/safe-string.js'
         ]);
       });
   });

--- a/tests/htmlbars-package-test.js
+++ b/tests/htmlbars-package-test.js
@@ -38,9 +38,9 @@ describe('htmlbars-package', function() {
   */
   it('correctly creates a htmlbars tree', function() {
     var expected = [
+      'htmlbars-util.js',
       'htmlbars-util/',
-      'htmlbars-util/safe-string.js',
-      'htmlbars-util.js'
+      'htmlbars-util/safe-string.js'
     ];
 
     var tree = htmlbarsPackage('htmlbars-util', {


### PR DESCRIPTION
As of https://github.com/emberjs/ember.js/pull/13843 these packages are now used only for generating `ember-template-compiler.js` asset, and are not required for runtime concerns.