### PR TITLE
Babel plugin cache invalidation has been fixed, use it.

### DIFF
--- a/lib/utils/babel-enifed-module-formatter.js
+++ b/lib/utils/babel-enifed-module-formatter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function(babel) {
+function enifedModuleFormatter(babel) {
   var t = babel.types;
 
   return new babel.Plugin('define-to-enifed', {
@@ -15,4 +15,10 @@ module.exports = function(babel) {
       }
     }
   });
+}
+
+enifedModuleFormatter.baseDir = function() {
+  return __dirname;
 };
+
+module.exports = enifedModuleFormatter;

--- a/lib/utils/conditional-use-strict-babel-plugin.js
+++ b/lib/utils/conditional-use-strict-babel-plugin.js
@@ -2,7 +2,7 @@
 
 var THIS_BREAK_KEYS = ['FunctionExpression', 'FunctionDeclaration', 'ClassProperty'];
 
-module.exports = function(babel) {
+function conditionalUseStrict(babel) {
   var t = babel.types;
 
   function isStrictDirective(node) {
@@ -52,4 +52,10 @@ module.exports = function(babel) {
       }
     }
   });
+}
+
+conditionalUseStrict.baseDir = function() {
+  return __dirname;
 };
+
+module.exports = conditionalUseStrict;

--- a/lib/utils/transpile-es6.js
+++ b/lib/utils/transpile-es6.js
@@ -7,8 +7,6 @@ var conditionalUseStrict = require('./conditional-use-strict-babel-plugin');
 var enifedFormatter = require('./babel-enifed-module-formatter');
 var resolveModules = require('amd-name-resolver').resolveModules;
 var moduleResolver = resolveModules({ throwOnRootAccess: false });
-var stringify  = require('json-stable-stringify');
-var crypto     = require('crypto');
 
 module.exports = function(tree, description, _options) {
   var options = assign({
@@ -50,46 +48,6 @@ module.exports = function(tree, description, _options) {
   delete options.avoidDefine;
 
   var outputTree = transpileES6(tree, options);
-  // override default optionsHash until we can land
-  // https://github.com/babel/broccoli-babel-transpiler/pull/89
-  outputTree.optionsHash = function() {
-    var options = this.options;
-    var hash = {};
-    var key, value;
-
-    if (!this._optionsHash) {
-      for (key in options) {
-        value = options[key];
-        hash[key] = (typeof value === 'function') ? (value + '') : value;
-      }
-
-      if (options.plugins) {
-        hash.plugins = [];
-
-        for (var i = 0; i < options.plugins.length; i++) {
-          var plugin = options.plugins[i];
-
-          // do not look for `._augmentCacheKey` on string plugins
-          var pluginType = typeof plugin;
-          var pluginAugmentsCacheKey = (
-            (pluginType === 'object' || pluginType === 'function')
-              && typeof plugin._augmentCacheKey === 'function'
-          );
-          if (pluginType === 'string') {
-            hash.plugins.push(plugin);
-          } else if (pluginAugmentsCacheKey) {
-            hash.plugins.push(plugin._augmentCacheKey());
-          } else {
-            hash.plugins.push(plugin + '');
-          }
-        }
-      }
-
-      this._optionsHash = crypto.createHash('md5').update(stringify(hash), 'utf8').digest('hex');
-    }
-
-    return this._optionsHash;
-  };
 
   if (description) {
     outputTree.description = description;


### PR DESCRIPTION
This removes the custom monkey patches that we did to add proper
invalidations to the feature flagging plugin.  This has now been fixed
upstream by default.

See https://github.com/babel/broccoli-babel-transpiler/pull/89 for details.