### PR TITLE
Remove usage of glimmer-template-precompiler.

### DIFF
--- a/lib/ember-build.js
+++ b/lib/ember-build.js
@@ -229,6 +229,7 @@ var EmberBuild = CoreObject.extend({
 
       currentPackage.trees = es6Package(packages, packageName, {
         htmlbars: this.htmlbars,
+        glimmer: this.glimmer,
         vendoredPackages: vendoredPackages
       });
 

--- a/lib/get-es6-package.js
+++ b/lib/get-es6-package.js
@@ -110,7 +110,9 @@ function getES6Package(packages, packageName, opts) {
         htmlbars: options.htmlbars
       });
     } else if (packageName.indexOf('glimmer') > -1) {
-      libTree = glimmerTemplatePrecompiler(libTree);
+      libTree = glimmerTemplatePrecompiler(libTree, {
+        glimmer: options.glimmer
+      });
     }
   }
 

--- a/lib/utils/glimmer-template-precompiler.js
+++ b/lib/utils/glimmer-template-precompiler.js
@@ -1,18 +1,21 @@
 'use strict';
 
 var Filter = require('broccoli-persistent-filter');
-var compile = require('glimmer-engine-precompiler');
 
 GlimmerTemplatePrecompiler.prototype = Object.create(Filter.prototype);
 
-function GlimmerTemplatePrecompiler (inputTree) {
+function GlimmerTemplatePrecompiler (inputTree, options) {
   if (!(this instanceof GlimmerTemplatePrecompiler)) {
-    return new GlimmerTemplatePrecompiler(inputTree);
+    return new GlimmerTemplatePrecompiler(inputTree, options);
   }
 
   Filter.call(this, inputTree, {});
 
   this.inputTree = inputTree;
+  if (!options.glimmer) {
+    throw new Error('No glimmer option provided!');
+  }
+  this.compile = options.glimmer.compileSpec;
 }
 
 GlimmerTemplatePrecompiler.prototype.extensions = ['hbs'];
@@ -22,8 +25,8 @@ GlimmerTemplatePrecompiler.prototype.baseDir = function() {
   return __dirname;
 };
 
-GlimmerTemplatePrecompiler.prototype.processString = function(content) {
-  var compiledSpec = compile(content);
+GlimmerTemplatePrecompiler.prototype.processString = function(content, relativePath) {
+  var compiledSpec = this.compile(content, { moduleName: relativePath });
   var template = 'import { template } from "ember-glimmer";\n';
   template += 'export default template(' + JSON.stringify(compiledSpec) + ');';
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "core-object": "0.0.4",
     "ember-cli-yuidoc": " 0.8.4",
     "git-repo-version": "0.3.0",
-    "glimmer-engine-precompiler": "0.5.0",
     "js-string-escape": "^1.0.0",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^3.10.1"


### PR DESCRIPTION
Require that the consuming app provide the `glimmer` to be used.