### PR TITLE
Invert `stripRuntimeChecks` option.

### DIFF
--- a/lib/concatenate-es6-modules.js
+++ b/lib/concatenate-es6-modules.js
@@ -48,7 +48,7 @@ module.exports = function concatenateES6Modules(inputTrees, _options) {
 
   sourceTrees = transpileES6(sourceTrees, destFile, {
     plugins: options.babel ? options.babel.plugins : [],
-    stripRuntimeChecks: includeDevHelpers
+    stripRuntimeChecks: !includeDevHelpers
   });
 
   if (!loader) {

--- a/lib/utils/babel-enifed-module-formatter.js
+++ b/lib/utils/babel-enifed-module-formatter.js
@@ -23,4 +23,8 @@ enifedModuleFormatter.baseDir = function() {
   return path.join(__dirname, '..', '..');
 };
 
+enifedModuleFormatter.cacheKey = function() {
+  return 'define-to-enifed';
+};
+
 module.exports = enifedModuleFormatter;

--- a/lib/utils/babel-strip-class-call-check.js
+++ b/lib/utils/babel-strip-class-call-check.js
@@ -22,6 +22,7 @@ function stripClassCallCheck(babel) {
   });
 }
 
-stripClassCallCheck.baseDir = function() { return path.join(__dirname, '..', '..'); }
+stripClassCallCheck.baseDir = function() { return path.join(__dirname, '..', '..'); };
+stripClassCallCheck.cacheKey = function() { return 'strip-class-call-check'; };
 
 module.exports = stripClassCallCheck;


### PR DESCRIPTION
`options.includeDevHelpers` is specified when we are doing a `ember.debug.js` build.

Before this change, when `options.includeDevHelpers` was true we would strip the `class-call-check` helper from invocations but include the helper itself in the build ( as part of the `external-helpers-dev.js`), and when `optioins.includeDevHelpers` was `false` we would leave the `class-call-check` invocations in the build but **not** include the helper itself in the build (as part of the `external-helpers-prod.js` file).

As you can see the relationship between `includeDevHelpers` and `stripRuntimeChecks` must be an inverse relationship, or the production build will error.