### PR TITLE
Allow ember-templates package to be removed.

### DIFF
--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -23,14 +23,12 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
   es6Package(packages, 'ember-metal');
   es6Package(packages, 'ember-debug');
   es6Package(packages, 'ember-template-compiler');
-  es6Package(packages, 'ember-templates');
 
   var trees = [
     packages['ember-template-compiler'].trees.lib,
     packages['ember-debug'].trees.lib,
     packages['ember-console'].trees.lib,
     packages['ember-environment'].trees.lib,
-    packages['ember-templates'].trees.lib,
     createEmberVersion(options.version),
     compileEmberFeatures(options.features.development)
   ];

--- a/lib/utils/glimmer-template-precompiler.js
+++ b/lib/utils/glimmer-template-precompiler.js
@@ -27,7 +27,7 @@ GlimmerTemplatePrecompiler.prototype.baseDir = function() {
 
 GlimmerTemplatePrecompiler.prototype.processString = function(content, relativePath) {
   var compiledSpec = this.compile(content, { moduleName: relativePath });
-  var template = 'import { template } from "ember-glimmer";\n';
+  var template = 'import template from "../template";\n';
   template += 'export default template(' + JSON.stringify(compiledSpec) + ');';
 
   return template;


### PR DESCRIPTION
* Does not try to embed it in the ember-template-compiler.
* Updates import to use relative import for `template` function (all
  templates are in the same package so we should be using relative import).