### PR TITLE
Update ember-template-compiler.js output to include ember-utils.

### DIFF
--- a/lib/get-build-template-compiler-tree.js
+++ b/lib/get-build-template-compiler-tree.js
@@ -20,7 +20,7 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
 
   es6Package(packages, 'ember-environment');
   es6Package(packages, 'ember-console');
-  es6Package(packages, 'container');
+  es6Package(packages, 'ember-utils');
   es6Package(packages, 'ember-metal');
   es6Package(packages, 'ember-debug');
   es6Package(packages, 'ember-template-compiler');
@@ -30,7 +30,7 @@ module.exports = function buildTemplateCompilerTree(packages, _vendoredPackages,
     packages['ember-debug'].trees.lib,
     packages['ember-console'].trees.lib,
     packages['ember-environment'].trees.lib,
-    packages['container'].trees.lib,
+    packages['ember-utils'].trees.lib,
     createEmberVersion(options.version),
     compileEmberFeatures(options.features.development)
   ];

--- a/tests/ember-build-test.js
+++ b/tests/ember-build-test.js
@@ -88,6 +88,7 @@ describe('ember-build', function() {
         features: { development: {}, production: {} },
         packages: {
           'container': {},
+          'ember-utils': {},
           'ember-metal': {},
           'ember-environment': { skipTests: true },
           'ember-console': { skipTests: true },


### PR DESCRIPTION
This replaces the dependency on container (needed for `getOwner` / `setOwner` things).

In the long run, we need to move `assert` / `deprecate` / etc out of `ember-metal` so that we can remove ember-template-compiler's dep on `ember-metal` completely.