### PR TITLE
Point Travis badge to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 emberjs-build
 =============
 
-[![Build Status](https://travis-ci.org/emberjs/emberjs-build.svg)](https://travis-ci.org/emberjs/emberjs-build)
+[![Build Status](https://travis-ci.org/emberjs/emberjs-build.svg?branch=master)](https://travis-ci.org/emberjs/emberjs-build)
 
 [![Code Climate](https://codeclimate.com/github/emberjs/emberjs-build/badges/gpa.svg)](https://codeclimate.com/github/emberjs/emberjs-build)
 


### PR DESCRIPTION
Mistakingly thought `master` was red due to badge not pointing to the correct branch.