### PR TITLE
Moves ember-cli-yuidoc to a devDependency to reduce the size of this …

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-files": "^1.2.0",
+    "ember-cli-yuidoc": " 0.8.4",
     "htmlbars": "^0.11.1",
     "mocha": "^2.0.1",
     "mocha-eslint": "^2.0.2",
@@ -48,7 +49,6 @@
     "broccoli-string-replace": "0.1.1",
     "broccoli-uglify-sourcemap": "^1.0.1",
     "core-object": "0.0.4",
-    "ember-cli-yuidoc": " 0.8.4",
     "git-repo-version": "0.3.0",
     "js-string-escape": "^1.0.0",
     "json-stable-stringify": "^1.0.1",


### PR DESCRIPTION
…node_module

ember-yuidoc contribute to ~25MBs of extra node_modules that aren't required by the consumers of emberjs-build

![image](https://cloud.githubusercontent.com/assets/47388/25721886/e521c0bc-30c6-11e7-9d36-47bd99f6907b.png)

I started by using `ember-cli-template-lint` has a transitive dependency to `ember-js-build` (through template-lint and glimmer-engine). 

I considered moving `eslint` as well, but it seems like that is used by `get-es6-package.js` which it's only used by `ember-build`, but I don't know if consumers of this node_module may use those directly for some reason and I don't have enough context. Doing that may save us other 7.6 MBs 
